### PR TITLE
Modifier registry

### DIFF
--- a/src/main/java/cursedflames/bountifulbaubles/baubleeffect/BaubleAttributeModifierHandler.java
+++ b/src/main/java/cursedflames/bountifulbaubles/baubleeffect/BaubleAttributeModifierHandler.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.IAttribute;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
@@ -94,12 +95,12 @@ public class BaubleAttributeModifierHandler {
 				&&!player.world.isRemote) {
 			if (ModConfig.randomBaubleModifiersEnabled.getBoolean(true)
 					&&ModConfig.baubleModifiersEnabled.getBoolean(true))
-				EnumBaubleModifier.generateModifier(stack);
+				BaubleModifier.generateModifier(stack);
 		}
 		if ((!stack.hasTagCompound()||!stack.getTagCompound().hasKey("baubleModifier")))
 			return;
-		EnumBaubleModifier mod = EnumBaubleModifier
-				.get(stack.getTagCompound().getString("baubleModifier"));
+		BaubleModifier mod = ModifierRegistry
+				.getModifier(new ResourceLocation(stack.getTagCompound().getString("baubleModifier")));
 //		BountifulBaubles.logger.info(mod);
 		boolean modifier = stack.getItem() instanceof IItemAttributeModifier;
 		if (modifier) {
@@ -113,7 +114,7 @@ public class BaubleAttributeModifierHandler {
 						player.getEntityAttribute(a).applyModifier(itemMods.get(a));
 				}
 			}
-			if (mod!=null&&mod!=EnumBaubleModifier.NONE) {
+			if (mod != null) {
 				// player.getEntityAttribute(mod.attribute).applyModifier(new
 				// AttributeModifier());
 				int i = 0;
@@ -148,7 +149,7 @@ public class BaubleAttributeModifierHandler {
 					}
 				}
 			}
-			if (mod!=null&&mod!=EnumBaubleModifier.NONE) {
+			if (mod != null) {
 				for (int i = 0; i<baubles.getSlots(); i++) {
 					if (baubles.getStackInSlot(i).isEmpty()) {
 						removeModifier(player, mod, i);
@@ -166,7 +167,7 @@ public class BaubleAttributeModifierHandler {
 				&&!event.player.world.isRemote
 				&&ModConfig.randomBaubleModifiersEnabled.getBoolean(true)
 				&&ModConfig.baubleModifiersEnabled.getBoolean(true)) {
-			EnumBaubleModifier.generateModifier(stack);
+			BaubleModifier.generateModifier(stack);
 		}
 	}
 
@@ -183,11 +184,12 @@ public class BaubleAttributeModifierHandler {
 			return;
 		if (stack.hasTagCompound()&&stack.getTagCompound().hasKey("baubleModifier")) {
 			String mod = stack.getTagCompound().getString("baubleModifier");
-			if (!mod.equals("none")) {
+			ResourceLocation loc = new ResourceLocation(mod);
+			if (!mod.equals(ModifierRegistry.INVALID_MODIFIER.toString())) {
 				event.getToolTip().add(BountifulBaubles.proxy
-						.translate(BountifulBaubles.MODID+".modifier."+mod+".info"));
+						.translate(loc.getResourceDomain() + "." + loc.getResourcePath() +".info"));
 				String modName = BountifulBaubles.proxy
-						.translate(BountifulBaubles.MODID+".modifier."+mod+".name");
+						.translate(loc.getResourceDomain() + "." + loc.getResourcePath() +".name");
 				String name = event.getToolTip().get(0);
 				String colorCode = "";
 				while (name.length()>1&&name.charAt(0)=='\u00A7') {
@@ -202,26 +204,29 @@ public class BaubleAttributeModifierHandler {
 		}
 	}
 
-	public static void removeModifier(EntityPlayer player, EnumBaubleModifier mod, int slot) {
+	public static void removeModifier(EntityPlayer player, BaubleModifier mod, int slot) {
 		player.getEntityAttribute(mod.attribute).removeModifier(UUIDs.get(slot));
 	}
 
 	public static void removeAllSlotModifiers(EntityPlayer player, int slot) {
-		for (IAttribute attribute : EnumBaubleModifier.attributes) {
-			player.getEntityAttribute(attribute).removeModifier(UUIDs.get(slot));
+		for (BaubleModifier mod : ModifierRegistry.BAUBLE_MODIFIERS) {
+			player.getEntityAttribute(mod.attribute).removeModifier(UUIDs.get(slot));
 		}
 	}
 
 	public static void removeAllModifiers(EntityPlayer player) {
 		IBaublesItemHandler baubles = BaublesApi.getBaublesHandler(player);
 		for (int slot = 0; slot<baubles.getSlots(); slot++) {
-			for (IAttribute attribute : EnumBaubleModifier.attributes) {
-				player.getEntityAttribute(attribute).removeModifier(UUIDs.get(slot));
+			for (BaubleModifier mod : ModifierRegistry.BAUBLE_MODIFIERS) {
+				if (mod.attribute == null){
+					continue;
+				}
+				player.getEntityAttribute(mod.attribute).removeModifier(UUIDs.get(slot));
 			}
 		}
 	}
 
-	public static void addModifier(EntityPlayer player, EnumBaubleModifier mod, int slot) {
+	public static void addModifier(EntityPlayer player, BaubleModifier mod, int slot) {
 		if (player.getEntityAttribute(mod.attribute).getModifier(UUIDs.get(slot))==null) {
 			player.getEntityAttribute(mod.attribute)
 					.applyModifier(new AttributeModifier(UUIDs.get(slot),

--- a/src/main/java/cursedflames/bountifulbaubles/baubleeffect/BaubleAttributeModifierHandler.java
+++ b/src/main/java/cursedflames/bountifulbaubles/baubleeffect/BaubleAttributeModifierHandler.java
@@ -114,7 +114,7 @@ public class BaubleAttributeModifierHandler {
 						player.getEntityAttribute(a).applyModifier(itemMods.get(a));
 				}
 			}
-			if (mod != null) {
+			if (mod != null && !mod.getRegistryName().equals(ModifierRegistry.INVALID_MODIFIER)) {
 				// player.getEntityAttribute(mod.attribute).applyModifier(new
 				// AttributeModifier());
 				int i = 0;
@@ -149,7 +149,7 @@ public class BaubleAttributeModifierHandler {
 					}
 				}
 			}
-			if (mod != null) {
+			if (mod != null && !mod.getRegistryName().equals(ModifierRegistry.INVALID_MODIFIER)) {
 				for (int i = 0; i<baubles.getSlots(); i++) {
 					if (baubles.getStackInSlot(i).isEmpty()) {
 						removeModifier(player, mod, i);

--- a/src/main/java/cursedflames/bountifulbaubles/baubleeffect/BaubleModifier.java
+++ b/src/main/java/cursedflames/bountifulbaubles/baubleeffect/BaubleModifier.java
@@ -1,0 +1,66 @@
+package cursedflames.bountifulbaubles.baubleeffect;
+
+import baubles.api.cap.BaublesCapabilities;
+import net.minecraft.entity.ai.attributes.IAttribute;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import javax.annotation.Nullable;
+import java.util.Random;
+
+public class BaubleModifier extends IForgeRegistryEntry.Impl<BaubleModifier>{
+    public final IAttribute attribute;
+    public final double amount;
+    public final int operation;
+    public final int weight;
+
+    public BaubleModifier(ResourceLocation name, IAttribute attribute, double amount, int operation, int weight){
+        setRegistryName(name);
+        this.weight = weight;
+        this.amount = amount;
+        this.operation = operation;
+        this.attribute = attribute;
+    }
+
+    private static final Random RANDOM = new Random();
+
+    public void addTo(ItemStack stack) {
+        if (!stack.hasTagCompound()) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
+        NBTTagCompound tag = stack.getTagCompound();
+        tag.setString("baubleModifier", getRegistryName().toString());
+    }
+
+    private static int getTotalWeight() {
+        int total = 0;
+        for (BaubleModifier mod : ModifierRegistry.BAUBLE_MODIFIERS) {
+            total += mod.weight;
+        }
+        return total;
+    }
+
+    @Nullable
+    public static BaubleModifier getWeightedRandom() {
+        int rand = RANDOM.nextInt(getTotalWeight());
+        int currentWeight = 0;
+        for (BaubleModifier mod : ModifierRegistry.BAUBLE_MODIFIERS) {
+            currentWeight += mod.weight;
+            if (rand<currentWeight)
+                return mod;
+        }
+        // this should be unreachable
+        return null;
+    }
+
+    public static void generateModifier(ItemStack stack) {
+        if (!stack.hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null))
+            return;
+        BaubleModifier toAdd = getWeightedRandom();
+        if (toAdd != null && !toAdd.getRegistryName().equals(ModifierRegistry.INVALID_MODIFIER)){
+            toAdd.addTo(stack);
+        }
+    }
+}

--- a/src/main/java/cursedflames/bountifulbaubles/baubleeffect/EnumBaubleModifier.java
+++ b/src/main/java/cursedflames/bountifulbaubles/baubleeffect/EnumBaubleModifier.java
@@ -1,42 +1,33 @@
 package cursedflames.bountifulbaubles.baubleeffect;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Random;
 import java.util.Set;
 
-import baubles.api.cap.BaublesCapabilities;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.IAttribute;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 
 //TODO way to have non-attribute effects
-//TODO switch away from enums so other mods can register modifiers
 //TODO investigate adding runic shielding from TC?
 public enum EnumBaubleModifier {
-	NONE("none", null, 0, 0, 5),
-	HALF_HEARTED("half_hearted", SharedMonsterAttributes.MAX_HEALTH, 1, 0, 3),
-	HEARTY("hearty", SharedMonsterAttributes.MAX_HEALTH, 2, 0, 1),
-	HARD("hard", SharedMonsterAttributes.ARMOR, 1, 0, 3),
-	GUARDING("guarding", SharedMonsterAttributes.ARMOR, 1.5, 0, 2),
-	ARMORED("armored", SharedMonsterAttributes.ARMOR, 2, 0, 1),
-	WARDING("warding", SharedMonsterAttributes.ARMOR_TOUGHNESS, 1, 0, 2),
-	JAGGED("jagged", SharedMonsterAttributes.ATTACK_DAMAGE, 0.02, 2, 2),
-	SPIKED("spiked", SharedMonsterAttributes.ATTACK_DAMAGE, 0.04, 2, 2),
-	ANGRY("angry", SharedMonsterAttributes.ATTACK_DAMAGE, 0.06, 2, 1),
-	MENACING("menacing", SharedMonsterAttributes.ATTACK_DAMAGE, 0.08, 2, 1),
-	BRISK("brisk", SharedMonsterAttributes.MOVEMENT_SPEED, 0.01, 2, 2),
-	FLEETING("fleeting", SharedMonsterAttributes.MOVEMENT_SPEED, 0.02, 2, 2),
-	HASTY("hasty", SharedMonsterAttributes.MOVEMENT_SPEED, 0.03, 2, 1),
-	QUICK("quick", SharedMonsterAttributes.MOVEMENT_SPEED, 0.04, 2, 1),
-	WILD("wild", SharedMonsterAttributes.ATTACK_SPEED, 0.02, 2, 2),
-	RASH("rash", SharedMonsterAttributes.ATTACK_SPEED, 0.04, 2, 2),
-	INTREPID("intrepid", SharedMonsterAttributes.ATTACK_SPEED, 0.06, 2, 1),
-	VIOLENT("violent", SharedMonsterAttributes.ATTACK_SPEED, 0.08, 2, 1);
+	NONE("modifier.none", null, 0, 0, 5),
+	HALF_HEARTED("modifier.half_hearted", SharedMonsterAttributes.MAX_HEALTH, 1, 0, 3),
+	HEARTY("modifier.hearty", SharedMonsterAttributes.MAX_HEALTH, 2, 0, 1),
+	HARD("modifier.hard", SharedMonsterAttributes.ARMOR, 1, 0, 3),
+	GUARDING("modifier.guarding", SharedMonsterAttributes.ARMOR, 1.5, 0, 2),
+	ARMORED("modifier.armored", SharedMonsterAttributes.ARMOR, 2, 0, 1),
+	WARDING("modifier.warding", SharedMonsterAttributes.ARMOR_TOUGHNESS, 1, 0, 2),
+	JAGGED("modifier.jagged", SharedMonsterAttributes.ATTACK_DAMAGE, 0.02, 2, 2),
+	SPIKED("modifier.spiked", SharedMonsterAttributes.ATTACK_DAMAGE, 0.04, 2, 2),
+	ANGRY("modifier.angry", SharedMonsterAttributes.ATTACK_DAMAGE, 0.06, 2, 1),
+	MENACING("modifier.menacing", SharedMonsterAttributes.ATTACK_DAMAGE, 0.08, 2, 1),
+	BRISK("modifier.brisk", SharedMonsterAttributes.MOVEMENT_SPEED, 0.01, 2, 2),
+	FLEETING("modifier.fleeting", SharedMonsterAttributes.MOVEMENT_SPEED, 0.02, 2, 2),
+	HASTY("modifier.hasty", SharedMonsterAttributes.MOVEMENT_SPEED, 0.03, 2, 1),
+	QUICK("modifier.quick", SharedMonsterAttributes.MOVEMENT_SPEED, 0.04, 2, 1),
+	WILD("modifier.wild", SharedMonsterAttributes.ATTACK_SPEED, 0.02, 2, 2),
+	RASH("modifier.rash", SharedMonsterAttributes.ATTACK_SPEED, 0.04, 2, 2),
+	INTREPID("modifier.intrepid", SharedMonsterAttributes.ATTACK_SPEED, 0.06, 2, 1),
+	VIOLENT("modifier.violent", SharedMonsterAttributes.ATTACK_SPEED, 0.08, 2, 1);
 	public final String name;
 	public final IAttribute attribute;
 	public final double amount;
@@ -52,59 +43,11 @@ public enum EnumBaubleModifier {
 	}
 
 	EnumBaubleModifier(String name, IAttribute attribute, double amount, int operation,
-			int weight) {
+					   int weight) {
 		this.name = name;
 		this.attribute = attribute;
 		this.amount = amount;
 		this.operation = operation;
 		this.weight = weight;
-	}
-
-	private static final List<EnumBaubleModifier> VALUES = Collections
-			.unmodifiableList(Arrays.asList(values()));
-
-	private static final int getTotalWeight() {
-		int total = 0;
-		for (EnumBaubleModifier mod : VALUES) {
-			total += mod.weight;
-		}
-		return total;
-	}
-
-	private static final int TOTAL_WEIGHT = getTotalWeight();
-	private static final Random RANDOM = new Random();
-
-	public static EnumBaubleModifier getWeightedRandom() {
-		int rand = RANDOM.nextInt(TOTAL_WEIGHT);
-		int currentWeight = 0;
-		for (EnumBaubleModifier mod : VALUES) {
-			currentWeight += mod.weight;
-			if (rand<currentWeight)
-				return mod;
-		}
-		// this should be unreachable
-		return NONE;
-	}
-
-	public static void generateModifier(ItemStack stack) {
-		if (!stack.hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null))
-			return;
-		getWeightedRandom().addTo(stack);
-	}
-
-	public void addTo(ItemStack stack) {
-		if (!stack.hasTagCompound()) {
-			stack.setTagCompound(new NBTTagCompound());
-		}
-		NBTTagCompound tag = stack.getTagCompound();
-		tag.setString("baubleModifier", name);
-	}
-
-	public static EnumBaubleModifier get(String str) {
-		try {
-			return EnumBaubleModifier.valueOf(str.toUpperCase(Locale.ENGLISH));
-		} catch (Exception e) {
-			return null;
-		}
 	}
 }

--- a/src/main/java/cursedflames/bountifulbaubles/baubleeffect/ModifierRegistry.java
+++ b/src/main/java/cursedflames/bountifulbaubles/baubleeffect/ModifierRegistry.java
@@ -1,0 +1,44 @@
+package cursedflames.bountifulbaubles.baubleeffect;
+
+import cursedflames.bountifulbaubles.BountifulBaubles;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.RegistryBuilder;
+
+import javax.annotation.Nullable;
+
+@Mod.EventBusSubscriber
+public class ModifierRegistry {
+    public static IForgeRegistry<BaubleModifier> BAUBLE_MODIFIERS = null;
+    public static final ResourceLocation INVALID_MODIFIER = new ResourceLocation(BountifulBaubles.MODID,
+            "modifier.none");
+
+    @Nullable
+    public static BaubleModifier getModifier(ResourceLocation name){ return BAUBLE_MODIFIERS.getValue(name); }
+
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public static void createRegistry(RegistryEvent.NewRegistry event) {
+        BAUBLE_MODIFIERS = new RegistryBuilder<BaubleModifier>()
+                .setName(new ResourceLocation(BountifulBaubles.MODID, "modifiers"))
+                .setType(BaubleModifier.class)
+                .setIDRange(0, Integer.MAX_VALUE - 1)
+                .create();
+    }
+
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public static void registerBaubleModifiers(RegistryEvent.Register<BaubleModifier> event) {
+        for (EnumBaubleModifier mod : EnumBaubleModifier.values()){
+            BaubleModifier baubleModifier = new BaubleModifier(
+                    new ResourceLocation(BountifulBaubles.MODID, mod.name),
+                    mod.attribute, mod.amount, mod.operation, mod.weight);
+            event.getRegistry().register(baubleModifier);
+        }
+    }
+}
+
+

--- a/src/main/java/cursedflames/bountifulbaubles/block/TileReforger.java
+++ b/src/main/java/cursedflames/bountifulbaubles/block/TileReforger.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import baubles.api.cap.BaublesCapabilities;
 import cursedflames.bountifulbaubles.ModConfig;
+import cursedflames.bountifulbaubles.baubleeffect.BaubleModifier;
 import cursedflames.bountifulbaubles.baubleeffect.EnumBaubleModifier;
 import cursedflames.lib.block.GenericTileEntity;
 import cursedflames.lib.util.XpUtil;
@@ -29,7 +30,7 @@ public class TileReforger extends GenericTileEntity {
 			}
 			NBTTagCompound tag = stack.getTagCompound();
 			if (!tag.hasKey("baubleModifier"))
-				EnumBaubleModifier.generateModifier(stack);
+				BaubleModifier.generateModifier(stack);
 			if (!tag.hasKey("reforgeCost")) {
 				tag.setInteger("reforgeCost", getReforgeCost(world.rand));
 			}
@@ -87,7 +88,7 @@ public class TileReforger extends GenericTileEntity {
 		if ((xp>=xpCost||creative)&&xpCost!=-1) {
 			if (!creative)
 				XpUtil.addPlayerXP(player, -xpCost);
-			EnumBaubleModifier.generateModifier(stack);
+			BaubleModifier.generateModifier(stack);
 			tag.setInteger("reforgeCost", getReforgeCost(world.rand));
 			float vol = (float) (Math.random()*0.3+0.9);
 			float pitch = (float) (Math.random()*0.3+0.85);


### PR DESCRIPTION
Addresses #7 

I tried to cause as few side effects as possible, but one major change was TotalWeight is no longer cached. I don't think this will necessarily be a problem given the infrequency of the use, but if you did want to restore this behavior we could do a post_init that runs through the registry and calculates it then. All modifiers will be registered at that point.