### PR TITLE
Firstaid compat

### DIFF
--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemTrinketBrokenHeart.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemTrinketBrokenHeart.java
@@ -6,6 +6,10 @@ import baubles.api.BaubleType;
 import baubles.api.BaublesApi;
 import cursedflames.bountifulbaubles.BountifulBaubles;
 import cursedflames.lib.config.Config.EnumPropSide;
+import ichttt.mods.firstaid.api.FirstAidRegistry;
+import ichttt.mods.firstaid.api.damagesystem.AbstractDamageablePart;
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel;
+import ichttt.mods.firstaid.api.event.FirstAidLivingDamageEvent;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.IAttributeInstance;
@@ -47,6 +51,7 @@ public class ItemTrinketBrokenHeart extends AGenericItemBauble {
 	public static void onDamage(LivingDamageEvent event) {
 		if (!(event.getEntity() instanceof EntityPlayer))
 			return;
+		if (FirstAidRegistry.getImpl() != null) return; //Firstaid loaded and present - see code below
 		EntityPlayer player = (EntityPlayer) event.getEntity();
 //		BountifulBaubles.logger.info("playerhit");
 		if (BaublesApi.isBaubleEquipped(player, ModItems.trinketBrokenHeart)==-1)
@@ -74,6 +79,44 @@ public class ItemTrinketBrokenHeart extends AGenericItemBauble {
 			event.setCanceled(true);
 		}
 		event.setAmount((float) (Math.max(event.getAmount()-maxHealthDamage, 0)));
+
+//		player.world.playSound(null, player.posX, player.posY, player.posZ,
+//				SoundEvents.ENTITY_PLAYER_HURT, SoundCategory.PLAYERS, 1.0F,
+//				(player.world.rand.nextFloat()-player.world.rand.nextFloat())*0.15F+0.75F);
+		player.world.playSound(null, player.posX, player.posY, player.posZ,
+				SoundEvents.ENTITY_IRONGOLEM_HURT, SoundCategory.PLAYERS, 0.7F,
+				(player.world.rand.nextFloat()-player.world.rand.nextFloat())*0.1F+0.8F);
+	}
+
+	@SubscribeEvent
+	public static void onFirstAidDamage(FirstAidLivingDamageEvent event) {
+		EntityPlayer player = event.getEntityPlayer();
+//		BountifulBaubles.logger.info("playerhit");
+		if (BaublesApi.isBaubleEquipped(player, ModItems.trinketBrokenHeart)==-1)
+			return;
+		AbstractPlayerDamageModel afterDamage = event.getAfterDamage();
+		if (!afterDamage.isDead(player)) return;
+//		BountifulBaubles.logger.info("health after damage "+healthAfterDamage);
+		double maxHealthDamage = event.getUndistributedDamage();
+		for (AbstractDamageablePart damageablePart : afterDamage) {
+			if ((damageablePart.canCauseDeath || afterDamage.hasNoCritical()) && damageablePart.currentHealth < 1F) {
+				maxHealthDamage += (1F - damageablePart.currentHealth);
+			}
+		}
+
+//		BountifulBaubles.logger.info("damage to maxHealth "+maxHealthDamage);
+		IAttributeInstance maxHealth = player
+				.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH);
+		AttributeModifier modifier = maxHealth.getModifier(MODIFIER_UUID);
+		double prevMaxHealthDamage = 0;
+		if (modifier!=null) {
+			prevMaxHealthDamage = modifier.getAmount();
+			maxHealth.removeModifier(modifier);
+		}
+		modifier = new AttributeModifier(MODIFIER_UUID, "Broken Heart MaxHP drain",
+				prevMaxHealthDamage-maxHealthDamage, 0);
+		maxHealth.applyModifier(modifier);
+		afterDamage.revivePlayer(player);
 
 //		player.world.playSound(null, player.posX, player.posY, player.posZ,
 //				SoundEvents.ENTITY_PLAYER_HURT, SoundCategory.PLAYERS, 1.0F,

--- a/src/main/java/ichttt/mods/firstaid/api/CapabilityExtendedHealthSystem.java
+++ b/src/main/java/ichttt/mods/firstaid/api/CapabilityExtendedHealthSystem.java
@@ -1,0 +1,30 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api;
+
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+
+public class CapabilityExtendedHealthSystem {
+
+    @CapabilityInject(AbstractPlayerDamageModel.class)
+    public static Capability<AbstractPlayerDamageModel> INSTANCE;
+}

--- a/src/main/java/ichttt/mods/firstaid/api/FirstAidRegistry.java
+++ b/src/main/java/ichttt/mods/firstaid/api/FirstAidRegistry.java
@@ -1,0 +1,172 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api;
+
+import ichttt.mods.firstaid.api.damagesystem.AbstractPartHealer;
+import ichttt.mods.firstaid.api.debuff.IDebuff;
+import ichttt.mods.firstaid.api.debuff.builder.IDebuffBuilder;
+import ichttt.mods.firstaid.api.enums.EnumDebuffSlot;
+import ichttt.mods.firstaid.api.enums.EnumPlayerPart;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * The central registry for FirstAid.
+ * <br>
+ * Impl is set in PreInit, default values at init.
+ * If you want to register your own values, you should probably do it in init.
+ * If you want to override the default values, you should probably do it in PostInit.
+ * <br>
+ * <b>On LoadComplete event, all values should be present!</b>
+ */
+public abstract class FirstAidRegistry {
+    @Nullable
+    private static FirstAidRegistry instance;
+
+    /**
+     * DO NOT USE! ONLY FOR INTERNAL THINGS
+     */
+    public static void setImpl(@Nonnull FirstAidRegistry registry) {
+        instance = registry;
+    }
+
+    /**
+     * Use this to get the active instance.
+     * Null if FirstAid is not active or a version without this feature (prior to 1.3.2) is loaded
+     */
+    @Nullable
+    public static FirstAidRegistry getImpl() {
+        return instance;
+    }
+
+    /**
+     * @deprecated Use {@link #bindDamageSourceStandard(DamageSource, List, boolean)} instead
+     */
+    @Deprecated
+    public abstract void bindDamageSourceStandard(@Nonnull String damageType, @Nonnull List<Pair<EntityEquipmentSlot, EnumPlayerPart[]>> priorityTable);
+
+    /**
+     * Binds the damage source to a distribution.
+     * The distribution will be a StandardDamageDistribution
+     *
+     * @param damageType           The source - If you only have a source string, just wrap it in a {@link DamageSource (String)}
+     * @param priorityTable        The distribution table. If {@code shufflePriorityTable} is true,
+     *                             the first item on the list will be damaged first,
+     *                             if the health there drops under zero, the second will be damaged and so on.
+     *                             Otherwise, the list will be shuffled before each damage distribution
+     * @param shufflePriorityTable If the {@code priorityTable} should be shuffled before each distribution
+     */
+    public abstract void bindDamageSourceStandard(@Nonnull DamageSource damageType, @Nonnull List<Pair<EntityEquipmentSlot, EnumPlayerPart[]>> priorityTable, boolean shufflePriorityTable);
+
+    /**
+     * @deprecated Use {@link #bindDamageSourceRandom(DamageSource, boolean, boolean)} instead
+     */
+    @Deprecated
+    public abstract void bindDamageSourceRandom(@Nonnull String damageType, boolean nearestFirst, boolean tryNoKill);
+
+    /**
+     * Binds the damage source to a distribution.
+     * The distribution will be a RandomDamageDistribution
+     * This (with nearestFirst = true) is the default setting when nothing else is specified
+     *
+     * @param damageType   The source
+     * @param nearestFirst True, if only a random start point should be chosen and the nearest other parts will be damaged
+     *                     if the health there drops under zero, false if everything should be random
+     * @param tryNoKill    If true, head and torso will only drop to 1 health and will only die if there is nothing else left
+     */
+    public abstract void bindDamageSourceRandom(@Nonnull DamageSource damageType, boolean nearestFirst, boolean tryNoKill);
+
+    /**
+     * @deprecated Use {@link #bindDamageSourceCustom(DamageSource, IDamageDistribution)} instead
+     */
+    @Deprecated
+    public abstract void bindDamageSourceCustom(@Nonnull String damageType, @Nonnull IDamageDistribution distributionTable);
+
+    /**
+     * Binds the damage source to a custom distribution
+     *
+     * @param damageType        The source
+     * @param distributionTable Your custom distribution
+     */
+    public abstract void bindDamageSourceCustom(@Nonnull DamageSource damageType, @Nonnull IDamageDistribution distributionTable);
+
+    /**
+     * Registers your debuff to the FirstAid mod.
+     *
+     * @param slot    The slot this debuff should be active on
+     * @param builder The builder containing all the information needed for the system.
+     *                To retrieve a new builder use {@link ichttt.mods.firstaid.api.debuff.builder.DebuffBuilderFactory}
+     */
+    public abstract void registerDebuff(@Nonnull EnumDebuffSlot slot, @Nonnull IDebuffBuilder builder);
+
+    /**
+     * Registers you debuff to the FirstAid mod.
+     * If you just need a simple onHit or constant debuff, you might want to use {@link #registerDebuff(EnumDebuffSlot, IDebuffBuilder)}
+     *
+     * @param slot   The slot this debuff should be active on
+     * @param debuff Your custom implementation of a debuff
+     */
+    public abstract void registerDebuff(@Nonnull EnumDebuffSlot slot, @Nonnull Supplier<IDebuff> debuff);
+
+    /**
+     * Registers a healing type, so it can be used by the damage system when the user applies it.
+     *
+     * @param item      The item to bind to
+     * @param factory   The factory to create a new healing type.
+     *                  This should always create a new healer and get the itemstack that will shrink after creating the healer
+     * @param applyTime The time it takes to apply this in the UI
+     */
+    @Deprecated
+    public abstract void registerHealingType(@Nonnull Item item, @Nonnull Function<ItemStack, AbstractPartHealer> factory, int applyTime);
+
+    /**
+     * Registers a healing type, so it can be used by the damage system when the user applies it.
+     *
+     * @param item      The item to bind to
+     * @param factory   The factory to create a new healing type.
+     *                  This should always create a new healer and get the itemstack that will shrink after creating the healer
+     * @param applyTime The time it takes to apply this in the UI
+     */
+    public abstract void registerHealingType(@Nonnull Item item, @Nonnull Function<ItemStack, AbstractPartHealer> factory, Function<ItemStack, Integer> applyTime);
+
+    @Nullable
+    public abstract AbstractPartHealer getPartHealer(@Nonnull ItemStack type);
+
+    @Deprecated
+    @Nullable
+    public abstract Integer getPartHealingTime(@Nonnull Item item);
+
+    public abstract Integer getPartHealingTime(@Nonnull ItemStack itemStack);
+
+    @Nonnull
+    public abstract IDamageDistribution getDamageDistribution(@Nonnull DamageSource source);
+
+    @Nonnull
+    public abstract IDebuff[] getDebuffs(@Nonnull EnumDebuffSlot slot);
+}

--- a/src/main/java/ichttt/mods/firstaid/api/IDamageDistribution.java
+++ b/src/main/java/ichttt/mods/firstaid/api/IDamageDistribution.java
@@ -1,0 +1,30 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.DamageSource;
+
+import javax.annotation.Nonnull;
+
+public interface IDamageDistribution {
+
+    float distributeDamage(float damage, @Nonnull EntityPlayer player, @Nonnull DamageSource source, boolean addStat);
+}

--- a/src/main/java/ichttt/mods/firstaid/api/damagesystem/AbstractDamageablePart.java
+++ b/src/main/java/ichttt/mods/firstaid/api/damagesystem/AbstractDamageablePart.java
@@ -1,0 +1,90 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.damagesystem;
+
+import ichttt.mods.firstaid.api.enums.EnumPlayerPart;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.INBTSerializable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public abstract class AbstractDamageablePart implements INBTSerializable<NBTTagCompound> {
+    public final int initialMaxHealth;
+    public final boolean canCauseDeath;
+    @Nonnull
+    public final EnumPlayerPart part;
+    @Nullable
+    public AbstractPartHealer activeHealer;
+    public float currentHealth;
+
+    public AbstractDamageablePart(int maxHealth, boolean canCauseDeath, @Nonnull EnumPlayerPart playerPart) {
+        this.initialMaxHealth = maxHealth;
+        this.canCauseDeath = canCauseDeath;
+        this.part = playerPart;
+    }
+
+    /**
+     * Heals the part for the specified amount.
+     *
+     * @param amount      The amount the part should be healed, clamped to max health
+     * @param player      The entity that this part belongs to. May be null if applyDebuff is false, otherwise this is required nonnull
+     * @param applyDebuff If all registered debuffs should be notified of the healing done
+     * @return The amount of health that could not be added
+     */
+    public abstract float heal(float amount, @Nullable EntityPlayer player, boolean applyDebuff);
+
+    /**
+     * Damages the part for the specified amount.
+     *
+     * @param amount      The amount the part should be damaged, clamped to 0
+     * @param player      The entity that this part belongs to. May be null if applyDebuff is false, otherwise this is required nonnull
+     * @param applyDebuff If all registered debuffs should be notified of the damage taken
+     * @return The amount of damage that could not be done
+     */
+    public abstract float damage(float amount, @Nullable EntityPlayer player, boolean applyDebuff);
+
+    /**
+     * Damages the part for the specified amount.
+     *
+     * @param amount      The amount the part should be damaged, clamped to minHealth
+     * @param player      The entity that this part belongs to. May be null if applyDebuff is false, otherwise this is required nonnull
+     * @param applyDebuff If all registered debuffs should be notified of the damage taken
+     * @param minHealth   The minimum health the part should drop to
+     * @return The amount of damage that could not be done
+     */
+    public abstract float damage(float amount, @Nullable EntityPlayer player, boolean applyDebuff, float minHealth);
+
+    /**
+     * Updates the part.
+     * Should not be called by other mods!
+     */
+    public abstract void tick(World world, EntityPlayer player, boolean tickDebuffs);
+
+    public abstract void setAbsorption(float absorption);
+
+    public abstract float getAbsorption();
+
+    public abstract void setMaxHealth(int maxHealth);
+
+    public abstract int getMaxHealth();
+}

--- a/src/main/java/ichttt/mods/firstaid/api/damagesystem/AbstractPartHealer.java
+++ b/src/main/java/ichttt/mods/firstaid/api/damagesystem/AbstractPartHealer.java
@@ -1,0 +1,65 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.damagesystem;
+
+import net.minecraft.item.ItemStack;
+
+public abstract class AbstractPartHealer {
+    public final int maxHeal;
+    public final ItemStack stack;
+    public final int ticksPerHeal;
+
+    public AbstractPartHealer(int maxHeal, ItemStack stack, int ticksPerHeal) {
+        this.maxHeal = maxHeal;
+        this.stack = stack;
+        this.ticksPerHeal = ticksPerHeal;
+    }
+
+    /**
+     * Called when the part is loaded with saved data.
+     *
+     * @return this
+     */
+    public abstract AbstractPartHealer loadNBT(int ticksPassed, int heals);
+
+    /**
+     * Returns true if the healer is finished healing the body part.
+     * The healer will be removed from the part at the next tick
+     *
+     * @return True if the healer is finished, otherwise false
+     */
+    public abstract boolean hasFinished();
+
+    /**
+     * Updates the healer.
+     * Should not be called by other mods!
+     */
+    public abstract boolean tick();
+
+    /**
+     * Gets the time that passed since the
+     */
+    public abstract int getTicksPassed();
+
+    /**
+     * Gets the heals that this healer did
+     */
+    public abstract int getHealsDone();
+}

--- a/src/main/java/ichttt/mods/firstaid/api/damagesystem/AbstractPlayerDamageModel.java
+++ b/src/main/java/ichttt/mods/firstaid/api/damagesystem/AbstractPlayerDamageModel.java
@@ -1,0 +1,138 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.damagesystem;
+
+import ichttt.mods.firstaid.api.enums.EnumPlayerPart;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import javax.annotation.Nullable;
+
+public abstract class AbstractPlayerDamageModel implements Iterable<AbstractDamageablePart>, INBTSerializable<NBTTagCompound> {
+    public final AbstractDamageablePart HEAD;
+    public final AbstractDamageablePart LEFT_ARM;
+    public final AbstractDamageablePart LEFT_LEG;
+    public final AbstractDamageablePart LEFT_FOOT;
+    public final AbstractDamageablePart BODY;
+    public final AbstractDamageablePart RIGHT_ARM;
+    public final AbstractDamageablePart RIGHT_LEG;
+    public final AbstractDamageablePart RIGHT_FOOT;
+    public boolean hasTutorial;
+
+    public AbstractPlayerDamageModel(AbstractDamageablePart head, AbstractDamageablePart leftArm, AbstractDamageablePart leftLeg, AbstractDamageablePart leftFoot, AbstractDamageablePart body, AbstractDamageablePart rightArm, AbstractDamageablePart rightLeg, AbstractDamageablePart rightFoot) {
+        this.HEAD = head;
+        this.LEFT_ARM = leftArm;
+        this.LEFT_LEG = leftLeg;
+        this.LEFT_FOOT = leftFoot;
+        this.BODY = body;
+        this.RIGHT_ARM = rightArm;
+        this.RIGHT_LEG = rightLeg;
+        this.RIGHT_FOOT = rightFoot;
+    }
+
+    public AbstractDamageablePart getFromEnum(EnumPlayerPart part) {
+        switch (part) {
+            case HEAD:
+                return HEAD;
+            case LEFT_ARM:
+                return LEFT_ARM;
+            case LEFT_LEG:
+                return LEFT_LEG;
+            case BODY:
+                return BODY;
+            case RIGHT_ARM:
+                return RIGHT_ARM;
+            case RIGHT_LEG:
+                return RIGHT_LEG;
+            case LEFT_FOOT:
+                return LEFT_FOOT;
+            case RIGHT_FOOT:
+                return RIGHT_FOOT;
+            default:
+                throw new RuntimeException("Unknown enum " + part);
+        }
+    }
+
+    /**
+     * Updates the part.
+     * Should not be called by other mods!
+     */
+    public abstract void tick(World world, EntityPlayer player);
+
+    /**
+     * @deprecated Migrated to a potion effect, pass it in to directly apply
+     */
+    @Deprecated
+    public abstract void applyMorphine();
+
+    public abstract void applyMorphine(EntityPlayer player);
+
+    public abstract int getMorphineTicks();
+
+    public abstract float getCurrentHealth();
+
+    /**
+     * Checks if the player is dead.
+     * This does not mean that the player cannot be revived.
+     *
+     * @param player The player to check. If null, it will not be checked if the player can be revived (Using PlayerRevival)
+     * @return true if dead, false otherwise
+     */
+    public abstract boolean isDead(@Nullable EntityPlayer player);
+
+    public abstract Float getAbsorption();
+
+    public abstract void setAbsorption(float absorption);
+
+    public abstract int getCurrentMaxHealth();
+
+    @SideOnly(Side.CLIENT)
+    public abstract int getMaxRenderSize();
+
+    public abstract void sleepHeal(EntityPlayer player);
+
+    /**
+     * Internal for PlayerRevive compat
+     */
+    public abstract void stopWaitingForHelp(EntityPlayer player);
+
+    /**
+     * Internal for PlayerRevive compat
+     */
+    public abstract boolean isWaitingForHelp();
+
+    @Deprecated
+    public abstract void onNotHelped(EntityPlayer player);
+
+    @Deprecated
+    public abstract void onHelpedUp(EntityPlayer player);
+
+    public abstract void revivePlayer(EntityPlayer player);
+
+    public abstract void runScaleLogic(EntityPlayer player);
+
+    public abstract void scheduleResync();
+
+    public abstract boolean hasNoCritical();
+}

--- a/src/main/java/ichttt/mods/firstaid/api/debuff/IDebuff.java
+++ b/src/main/java/ichttt/mods/firstaid/api/debuff/IDebuff.java
@@ -1,0 +1,40 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.debuff;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+public interface IDebuff {
+
+    void handleDamageTaken(float damage, float healthPerMax, EntityPlayerMP player);
+
+    void handleHealing(float healingDone, float healthPerMax, EntityPlayerMP player);
+
+    default boolean isEnabled() {
+        return true;
+    }
+
+    default void update(EntityPlayer player) {}
+
+    default void update(EntityPlayer player, float healthPerMax) {
+        update(player);
+    }
+}

--- a/src/main/java/ichttt/mods/firstaid/api/debuff/builder/DebuffBuilderFactory.java
+++ b/src/main/java/ichttt/mods/firstaid/api/debuff/builder/DebuffBuilderFactory.java
@@ -1,0 +1,62 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.debuff.builder;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This is the class for the default builders. Use it whenever possible
+ */
+public abstract class DebuffBuilderFactory {
+    private static DebuffBuilderFactory instance;
+
+    /**
+     * DO NOT USE! ONLY FOR INTERNAL THINGS
+     */
+    public static void setInstance(DebuffBuilderFactory factory) {
+        instance = factory;
+    }
+
+    /**
+     * Use this to get the active instance.
+     * Null if FirstAid is not active or a version without this feature (prior to 1.4.2) is loaded
+     */
+    public static DebuffBuilderFactory getInstance() {
+        return instance;
+    }
+
+    /**
+     * Creates a new builder for a onHit debuff
+     *
+     * @param potionName The registry name of the potion
+     * @return A new builder
+     */
+    @Nonnull
+    public abstract IDebuffBuilder newOnHitDebuffBuilder(@Nonnull String potionName);
+
+    /**
+     * Creates a new builder for a constant debuff
+     *
+     * @param potionName The registry name of the potion
+     * @return A new builder
+     */
+    @Nonnull
+    public abstract IDebuffBuilder newConstantDebuffBuilder(@Nonnull String potionName);
+}

--- a/src/main/java/ichttt/mods/firstaid/api/debuff/builder/IDebuffBuilder.java
+++ b/src/main/java/ichttt/mods/firstaid/api/debuff/builder/IDebuffBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.debuff.builder;
+
+import ichttt.mods.firstaid.api.enums.EnumDebuffSlot;
+import net.minecraft.util.SoundEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Use this if you want to add simple onHit or constant debuffs.
+ * <br>
+ * If you want to do your own, custom implementation, you can use {@link ichttt.mods.firstaid.api.debuff.IDebuff}
+ * directly and register it using {@link ichttt.mods.firstaid.api.FirstAidRegistry#registerDebuff(EnumDebuffSlot, Supplier)}.
+ */
+public interface IDebuffBuilder {
+
+    /**
+     * Adds a sound to the debuff. The sound will be played as long as the debuff is timed.
+     * <b>Does only work with onHit debuffs!</b>
+     *
+     * @param event The sound that should be player
+     * @return this
+     */
+    @Nonnull
+    IDebuffBuilder addSoundEffect(@Nullable SoundEvent event);
+
+    /**
+     * If OnHit damage: value = absolute damage taken for this multiplier to apply;
+     * If Constant: value = percentage of health left for this multiplier
+     *
+     * @param value      absolute damage (onHit) or percentage of the health left (constant)
+     * @param multiplier the potion effect multiplier
+     * @return this
+     */
+    @Nonnull
+    IDebuffBuilder addBound(float value, int multiplier);
+
+    /**
+     * Provide a boolean supplier to control runtime-disabling of certain effects (e.g. via config)
+     *
+     * @param isEnabled A supplier that should return true if the debug should be applied
+     * @return this
+     */
+    @Nonnull
+    IDebuffBuilder addEnableCondition(@Nullable BooleanSupplier isEnabled);
+
+    /**
+     * Builds and registers this debuff to the FirstAid registry.
+     * This is the final step.
+     * This does the same as {@link ichttt.mods.firstaid.api.FirstAidRegistry#registerDebuff(EnumDebuffSlot, IDebuffBuilder)}
+     *
+     * @param slot The slot where the debuff should apply
+     */
+    void register(@Nonnull EnumDebuffSlot slot);
+}

--- a/src/main/java/ichttt/mods/firstaid/api/enums/EnumDebuffSlot.java
+++ b/src/main/java/ichttt/mods/firstaid/api/enums/EnumDebuffSlot.java
@@ -1,0 +1,35 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.enums;
+
+import javax.annotation.Nonnull;
+
+public enum EnumDebuffSlot {
+    HEAD(EnumPlayerPart.HEAD), BODY(EnumPlayerPart.BODY),
+    ARMS(EnumPlayerPart.LEFT_ARM, EnumPlayerPart.RIGHT_ARM),
+    LEGS_AND_FEET(EnumPlayerPart.LEFT_LEG, EnumPlayerPart.RIGHT_LEG, EnumPlayerPart.LEFT_FOOT, EnumPlayerPart.RIGHT_FOOT);
+
+    EnumDebuffSlot(@Nonnull EnumPlayerPart... playerParts) {
+        this.playerParts = playerParts;
+    }
+
+    @Nonnull
+    public final EnumPlayerPart[] playerParts;
+}

--- a/src/main/java/ichttt/mods/firstaid/api/enums/EnumPlayerPart.java
+++ b/src/main/java/ichttt/mods/firstaid/api/enums/EnumPlayerPart.java
@@ -1,0 +1,98 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.enums;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.inventory.EntityEquipmentSlot;
+
+public enum EnumPlayerPart {
+    HEAD(1, EntityEquipmentSlot.HEAD), LEFT_ARM(2, EntityEquipmentSlot.CHEST), LEFT_LEG(3, EntityEquipmentSlot.LEGS), LEFT_FOOT(4, EntityEquipmentSlot.FEET),
+    BODY(5, EntityEquipmentSlot.CHEST), RIGHT_ARM(6, EntityEquipmentSlot.CHEST), RIGHT_LEG(7, EntityEquipmentSlot.LEGS), RIGHT_FOOT(8, EntityEquipmentSlot.FEET);
+
+    public static final EnumPlayerPart[] VALUES = values();
+
+    public final byte id;
+    private ImmutableList<EnumPlayerPart> neighbours;
+    public final EntityEquipmentSlot slot;
+
+    EnumPlayerPart(int id, EntityEquipmentSlot slot) {
+        this.id = (byte) id;
+        this.slot = slot;
+    }
+
+    public ImmutableList<EnumPlayerPart> getNeighbours() {
+        if (neighbours == null) { // Need to do lazy init to avoid crashes when initializing class
+            ImmutableList.Builder<EnumPlayerPart> builder = ImmutableList.builder();
+            if (this.id != 5 && this.id != 1)
+                builder.add(getUp());
+            if (this.id != 4 && this.id != 8)
+                builder.add(getDown());
+            if (this.id > 4)
+                builder.add(getLeft());
+            else
+                builder.add(getRight());
+            neighbours = builder.build();
+        }
+        return neighbours;
+    }
+
+    public static EnumPlayerPart fromID(int id) {
+        switch (id) {
+            case 1:
+                return HEAD;
+            case 2:
+                return LEFT_ARM;
+            case 3:
+                return LEFT_LEG;
+            case 4:
+                return LEFT_FOOT;
+            case 5:
+                return BODY;
+            case 6:
+                return RIGHT_ARM;
+            case 7:
+                return RIGHT_LEG;
+            case 8:
+                return RIGHT_FOOT;
+        }
+        throw new IndexOutOfBoundsException("Invalid id " + id);
+    }
+
+    public EnumPlayerPart getUp() {
+        if (this.id == 5)
+            throw new IndexOutOfBoundsException("There is no part up from " + this.id);
+        return fromID(this.id - 1);
+    }
+
+    public EnumPlayerPart getDown() {
+        if (this.id == 4)
+            throw new IndexOutOfBoundsException("There is no part down from " + this.id);
+        return fromID(this.id + 1);
+    }
+
+    public EnumPlayerPart getLeft() {
+        return fromID(this.id - 4);
+    }
+
+    public EnumPlayerPart getRight() {
+        return fromID(this.id + 4);
+    }
+
+}

--- a/src/main/java/ichttt/mods/firstaid/api/event/FirstAidLivingDamageEvent.java
+++ b/src/main/java/ichttt/mods/firstaid/api/event/FirstAidLivingDamageEvent.java
@@ -1,0 +1,74 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.event;
+
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.DamageSource;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * Fired when the damage has been applied.
+ * Canceling this event will cause the damage to be reset to {@link #getBeforeDamage()}
+ */
+@Cancelable
+public class FirstAidLivingDamageEvent extends PlayerEvent {
+    private final AbstractPlayerDamageModel afterDamageDone;
+    private final AbstractPlayerDamageModel beforeDamageDone;
+    private final DamageSource source;
+    private final float undistributedDamage;
+
+    public FirstAidLivingDamageEvent(EntityPlayer entity, AbstractPlayerDamageModel afterDamageDone, AbstractPlayerDamageModel beforeDamageDone, DamageSource source, float undistributedDamage) {
+        super(entity);
+        this.afterDamageDone = afterDamageDone;
+        this.beforeDamageDone = beforeDamageDone;
+        this.source = source;
+        this.undistributedDamage = undistributedDamage;
+    }
+
+    /**
+     * @return The damage model before this damage got applied. Canceling this event causes this to be restored
+     */
+    public AbstractPlayerDamageModel getAfterDamage() {
+        return this.afterDamageDone;
+    }
+
+    /**
+     * @return The damage model after this damage got applied. Not canceling this event causes this to applied
+     */
+    public AbstractPlayerDamageModel getBeforeDamage() {
+        return this.beforeDamageDone;
+    }
+
+    /**
+     * @return The source from where the damage came
+     */
+    public DamageSource getSource() {
+        return this.source;
+    }
+
+    /**
+     * @return The damage that could not be distributed on any
+     */
+    public float getUndistributedDamage() {
+        return this.undistributedDamage;
+    }
+}

--- a/src/main/java/ichttt/mods/firstaid/api/item/HealingItemApiHelper.java
+++ b/src/main/java/ichttt/mods/firstaid/api/item/HealingItemApiHelper.java
@@ -1,0 +1,49 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.item;
+
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumHand;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Methods that link to internal helper methods
+ */
+public abstract class HealingItemApiHelper {
+    static HealingItemApiHelper INSTANCE;
+
+    /**
+     * DO NOT USE! ONLY FOR INTERNAL THINGS
+     */
+    public static void setImpl(HealingItemApiHelper impl) {
+        INSTANCE = impl;
+    }
+
+    @Nonnull
+    public abstract ActionResult<ItemStack> onItemRightClick(ItemHealing itemHealing, World worldIn, EntityPlayer playerIn, EnumHand handIn);
+
+    @Nonnull
+    public abstract CreativeTabs getFirstAidTab();
+}

--- a/src/main/java/ichttt/mods/firstaid/api/item/ItemHealing.java
+++ b/src/main/java/ichttt/mods/firstaid/api/item/ItemHealing.java
@@ -1,0 +1,57 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package ichttt.mods.firstaid.api.item;
+
+import ichttt.mods.firstaid.api.FirstAidRegistry;
+import ichttt.mods.firstaid.api.damagesystem.AbstractPartHealer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumHand;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Base class for custom healing items. Handles the logic for healing automatically.
+ * Registry name, stack size and other behavior can be specified individually.
+ * Will automatically register this item to the registry as well
+ */
+public class ItemHealing extends Item {
+
+    /**
+     * Creates a new healing item and registers it to the registry.
+     * @param time The time it takes in the GUI in ms
+     * @param healerFunction The function to create a new healer from the GUI
+     */
+    public ItemHealing(Function<ItemStack, AbstractPartHealer> healerFunction, Function<ItemStack, Integer> time) {
+        setCreativeTab(HealingItemApiHelper.INSTANCE.getFirstAidTab());
+        Objects.requireNonNull(FirstAidRegistry.getImpl(), "FirstAid not loaded or not present!").registerHealingType(this, healerFunction, time);
+    }
+
+    @Nonnull
+    @Override
+    public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, @Nonnull EnumHand handIn) {
+        return HealingItemApiHelper.INSTANCE.onItemRightClick(this, worldIn, playerIn, handIn);
+    }
+}

--- a/src/main/java/ichttt/mods/firstaid/api/package-info.java
+++ b/src/main/java/ichttt/mods/firstaid/api/package-info.java
@@ -1,0 +1,41 @@
+/*
+ * FirstAid API
+ * Copyright (c) 2017-2019
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * API for the FirstAid mod:
+ * List of API versions mapped to FirstAid version where they have been introduced:
+ * API Version: FirstAid Version (Major Changes)
+ * 1:  1.3.2 (Initial draft)
+ * 2:  1.3.3 (Introduction of the registry)
+ * 3:  1.4.0 (Minor changes)
+ * 4:  1.4.3 (Overhaul of the registry, especially healing item and debuff registry)
+ * 5:  1.4.4 (Minor changes)
+ * 6:  1.4.6 (Minor changes)
+ * 7:  1.5.0 (Apply time for healing items added)
+ * 8:  1.5.6 (Removed deprecated methods and fields)
+ * 9:  1.5.7 (Minor changes)
+ * 10: 1.5.9 (ItemHealing addition)
+ * 11: 1.5.10 (BREAKING CHANGE - Changed debuffs registration to supplier based)
+ * 12: 1.6.5 (Minor changes)
+ * 13: 1.6.7 (Debuffs now take DamageSource instead of String, FirstAidLivingDamageEvent)
+ */
+@API(apiVersion = "13", provides = "FirstAid API", owner = "firstaid")
+package ichttt.mods.firstaid.api;
+
+import net.minecraftforge.fml.common.API;


### PR DESCRIPTION
Hi CursedFlames,
I own a mod called FirstAid, which drastically changes the vanilla health system, and unfortunally you mod is incompatible with it at the moment, because FirstAid changes the way how your health is managed. I added some compat code to the ItemTrinketBrokenHeart to fix it.
I mostly copied the code from the `void onDamage(LivingDamageEvent event)` method and adjusted it so it works with firstaid.

Kind regards
ichttt