### PR TITLE
Updated mappings and added Mo'bends compat

### DIFF
--- a/src/main/java/cursedflames/bountifulbaubles/BountifulBaubles.java
+++ b/src/main/java/cursedflames/bountifulbaubles/BountifulBaubles.java
@@ -1,5 +1,8 @@
 package cursedflames.bountifulbaubles;
 
+import java.util.Map;
+import java.util.Map.Entry;
+
 import org.apache.logging.log4j.Logger;
 
 import cursedflames.bountifulbaubles.baubleeffect.BaubleAttributeModifierHandler;
@@ -7,6 +10,7 @@ import cursedflames.bountifulbaubles.block.ModBlocks;
 import cursedflames.bountifulbaubles.block.TESRReforger;
 import cursedflames.bountifulbaubles.block.TileReforger;
 import cursedflames.bountifulbaubles.capability.CapabilityWormholePins;
+import cursedflames.bountifulbaubles.client.layer.BountfulRenderLayer;
 import cursedflames.bountifulbaubles.entity.ModEntities;
 import cursedflames.bountifulbaubles.event.EventHandler;
 import cursedflames.bountifulbaubles.item.ItemAmuletSinGluttony;
@@ -25,6 +29,8 @@ import cursedflames.bountifulbaubles.util.Config;
 import cursedflames.bountifulbaubles.util.RegistryHelper;
 import cursedflames.bountifulbaubles.wormhole.CommandWormhole;
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -65,18 +71,20 @@ public class BountifulBaubles {
 
 	public static final String ARMOR_TEXTURE_PATH = "textures/models/armor/";
 
-//	static final Comparator<ItemStack> tabSorter;
+	//	static final Comparator<ItemStack> tabSorter;
 	public static final CreativeTabs TAB = new CreativeTabs("bountifulbaubles") {
+
+		@Override
 		@SideOnly(Side.CLIENT)
-		public ItemStack getTabIconItem() {
+		public ItemStack createIcon() {
 			return new ItemStack(ModItems.trinketObsidianSkull);
 		}
 
-//		@Override
-//        public void displayAllRelevantItems(NonNullList<ItemStack> items) {
-//            super.displayAllRelevantItems(items);
-//            items.sort(tabSorter);
-//        }
+		//		@Override
+		//        public void displayAllRelevantItems(NonNullList<ItemStack> items) {
+		//            super.displayAllRelevantItems(items);
+		//            items.sort(tabSorter);
+		//        }
 	};
 
 	public static boolean isQuarkLoaded = false;
@@ -93,6 +101,7 @@ public class BountifulBaubles {
 		config = new Config("1", logger);
 		config.preInit(event);
 		ModConfig.initConfig();
+
 		// TODO make some of these non-static and move registration to
 		// constructor
 		MinecraftForge.EVENT_BUS.register(EventHandler.class);
@@ -134,11 +143,27 @@ public class BountifulBaubles {
 		ClientRegistry.bindTileEntitySpecialRenderer(TileReforger.class, new TESRReforger());
 	}
 
+	@SideOnly(Side.CLIENT)
+	private static void addRenderLayer() {
+		final Map<String, RenderPlayer> skinMap = Minecraft.getMinecraft().getRenderManager().getSkinMap();
+		RenderPlayer render;
+		for (final Entry<String, RenderPlayer> map : skinMap.entrySet()) {
+			if (map.getKey().contentEquals("slim")) {
+				render = map.getValue();
+				render.addLayer(new BountfulRenderLayer(true, render));
+			} else {
+				render = map.getValue();
+				render.addLayer(new BountfulRenderLayer(false, render));
+			}
+		}
+	}
+
 	@Mod.EventHandler
 	public static void init(FMLInitializationEvent event) {
+		addRenderLayer();
 		ModItems.registerOtherModOreDictionaryEntries();
-//		List<Item> order = Arrays.asList(item1, item2, item3...);
-//		tabSorter = Ordering.explicit(order).onResultOf(ItemStack::getItem);
+		//		List<Item> order = Arrays.asList(item1, item2, item3...);
+		//		tabSorter = Ordering.explicit(order).onResultOf(ItemStack::getItem);
 		NetworkRegistry.INSTANCE.registerGuiHandler(instance, new GuiProxy());
 		PacketHandler.registerMessages();
 	}
@@ -146,11 +171,11 @@ public class BountifulBaubles {
 	@Mod.EventHandler
 	public static void postInit(FMLPostInitializationEvent event) {
 		config.postInit(event);
-//		logger.info(Config.modConfigs.get(MODID)==null);
-//		isQuarkLoaded = Loader.isModLoaded("quark");
-//		isBotaniaLoaded = Loader.isModLoaded("botania");
+		//		logger.info(Config.modConfigs.get(MODID)==null);
+		//		isQuarkLoaded = Loader.isModLoaded("quark");
+		//		isBotaniaLoaded = Loader.isModLoaded("botania");
 	}
-	
+
 	@Mod.EventHandler
 	public static void serverStart(FMLServerStartingEvent event) {
 		// TODO does using `new` screw things up?

--- a/src/main/java/cursedflames/bountifulbaubles/BountifulBaubles.java
+++ b/src/main/java/cursedflames/bountifulbaubles/BountifulBaubles.java
@@ -1,8 +1,5 @@
 package cursedflames.bountifulbaubles;
 
-import java.util.Map;
-import java.util.Map.Entry;
-
 import org.apache.logging.log4j.Logger;
 
 import cursedflames.bountifulbaubles.baubleeffect.BaubleAttributeModifierHandler;
@@ -10,7 +7,6 @@ import cursedflames.bountifulbaubles.block.ModBlocks;
 import cursedflames.bountifulbaubles.block.TESRReforger;
 import cursedflames.bountifulbaubles.block.TileReforger;
 import cursedflames.bountifulbaubles.capability.CapabilityWormholePins;
-import cursedflames.bountifulbaubles.client.layer.BountfulRenderLayer;
 import cursedflames.bountifulbaubles.entity.ModEntities;
 import cursedflames.bountifulbaubles.event.EventHandler;
 import cursedflames.bountifulbaubles.item.ItemAmuletSinGluttony;
@@ -29,8 +25,6 @@ import cursedflames.bountifulbaubles.util.Config;
 import cursedflames.bountifulbaubles.util.RegistryHelper;
 import cursedflames.bountifulbaubles.wormhole.CommandWormhole;
 import net.minecraft.block.Block;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -143,24 +137,9 @@ public class BountifulBaubles {
 		ClientRegistry.bindTileEntitySpecialRenderer(TileReforger.class, new TESRReforger());
 	}
 
-	@SideOnly(Side.CLIENT)
-	private static void addRenderLayer() {
-		final Map<String, RenderPlayer> skinMap = Minecraft.getMinecraft().getRenderManager().getSkinMap();
-		RenderPlayer render;
-		for (final Entry<String, RenderPlayer> map : skinMap.entrySet()) {
-			if (map.getKey().contentEquals("slim")) {
-				render = map.getValue();
-				render.addLayer(new BountfulRenderLayer(true, render));
-			} else {
-				render = map.getValue();
-				render.addLayer(new BountfulRenderLayer(false, render));
-			}
-		}
-	}
-
 	@Mod.EventHandler
 	public static void init(FMLInitializationEvent event) {
-		addRenderLayer();
+		proxy.addRenderLayer();
 		ModItems.registerOtherModOreDictionaryEntries();
 		//		List<Item> order = Arrays.asList(item1, item2, item3...);
 		//		tabSorter = Ordering.explicit(order).onResultOf(ItemStack::getItem);

--- a/src/main/java/cursedflames/bountifulbaubles/client/layer/BountfulRenderLayer.java
+++ b/src/main/java/cursedflames/bountifulbaubles/client/layer/BountfulRenderLayer.java
@@ -4,6 +4,7 @@ import org.lwjgl.opengl.GL11;
 
 import baubles.api.BaublesApi;
 import baubles.api.cap.IBaublesItemHandler;
+import baubles.api.render.IRenderBauble.RenderType;
 import javax.annotation.Nonnull;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.RenderPlayer;
@@ -38,11 +39,26 @@ public class BountfulRenderLayer implements LayerRenderer<EntityPlayer> {
 					GlStateManager.pushMatrix();
 					GL11.glColor3ub((byte) 255, (byte) 255, (byte) 255);
 					GlStateManager.color(1F, 1F, 1F, 1F);
-					renderObj.onRenderObject(stack, player, renderer, isSlim, partialTicks, scale);
+					if (player.isSneaking()) {
+						GlStateManager.translate(0, 0.2, 0);
+					}
+					this.renderType(renderObj.getRenderType(), scale);
+					renderObj.onRenderObject(stack, player, isSlim, partialTicks, scale);
 					GlStateManager.color(1F, 1F, 1F, 1F);
 					GlStateManager.popMatrix();
 				}
 			}
+		}
+	}
+
+	private void renderType(RenderType type, float scale) {
+		switch (type) {
+		case HEAD:
+			renderer.getMainModel().bipedHead.postRender(scale);
+		case BODY:
+			renderer.getMainModel().bipedBody.postRender(scale);
+		default:
+			break;
 		}
 	}
 

--- a/src/main/java/cursedflames/bountifulbaubles/client/layer/BountfulRenderLayer.java
+++ b/src/main/java/cursedflames/bountifulbaubles/client/layer/BountfulRenderLayer.java
@@ -36,6 +36,9 @@ public class BountfulRenderLayer implements LayerRenderer<EntityPlayer> {
 				final ItemStack stack = baubles.getStackInSlot(i);
 				if (stack.getItem() instanceof IRenderObject) {
 					final IRenderObject renderObj = (IRenderObject) stack.getItem();
+					if (renderObj.getRenderType() == null) {
+						return;
+					}
 					GlStateManager.pushMatrix();
 					GL11.glColor3ub((byte) 255, (byte) 255, (byte) 255);
 					GlStateManager.color(1F, 1F, 1F, 1F);

--- a/src/main/java/cursedflames/bountifulbaubles/client/layer/BountfulRenderLayer.java
+++ b/src/main/java/cursedflames/bountifulbaubles/client/layer/BountfulRenderLayer.java
@@ -1,0 +1,53 @@
+package cursedflames.bountifulbaubles.client.layer;
+
+import org.lwjgl.opengl.GL11;
+
+import baubles.api.BaublesApi;
+import baubles.api.cap.IBaublesItemHandler;
+import javax.annotation.Nonnull;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.entity.RenderPlayer;
+import net.minecraft.client.renderer.entity.layers.LayerRenderer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.MobEffects;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Loader;
+
+public class BountfulRenderLayer implements LayerRenderer<EntityPlayer> {
+
+	private boolean isSlim;
+	private RenderPlayer renderer;
+
+	public BountfulRenderLayer(boolean slim, RenderPlayer render) {
+		isSlim = slim;
+		renderer = render;
+	}
+
+	@Override
+	public void doRenderLayer(@Nonnull EntityPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
+		if (player.isInvisible() || (player.getActivePotionEffect(MobEffects.INVISIBILITY) != null)) {
+			return;
+		}
+
+		if (Loader.isModLoaded("baubles")) {
+			final IBaublesItemHandler baubles = BaublesApi.getBaublesHandler(player);
+			for (int i = 0; i < baubles.getSlots(); i++) {
+				final ItemStack stack = baubles.getStackInSlot(i);
+				if (stack.getItem() instanceof IRenderObject) {
+					final IRenderObject renderObj = (IRenderObject) stack.getItem();
+					GlStateManager.pushMatrix();
+					GL11.glColor3ub((byte) 255, (byte) 255, (byte) 255);
+					GlStateManager.color(1F, 1F, 1F, 1F);
+					renderObj.onRenderObject(stack, player, renderer, isSlim, partialTicks, scale);
+					GlStateManager.color(1F, 1F, 1F, 1F);
+					GlStateManager.popMatrix();
+				}
+			}
+		}
+	}
+
+	@Override
+	public boolean shouldCombineTextures() {
+		return false;
+	}
+}

--- a/src/main/java/cursedflames/bountifulbaubles/client/layer/IRenderObject.java
+++ b/src/main/java/cursedflames/bountifulbaubles/client/layer/IRenderObject.java
@@ -1,0 +1,11 @@
+package cursedflames.bountifulbaubles.client.layer;
+
+import net.minecraft.client.renderer.entity.RenderPlayer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+public interface IRenderObject {
+
+	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale);
+
+}

--- a/src/main/java/cursedflames/bountifulbaubles/client/layer/IRenderObject.java
+++ b/src/main/java/cursedflames/bountifulbaubles/client/layer/IRenderObject.java
@@ -1,11 +1,13 @@
 package cursedflames.bountifulbaubles.client.layer;
 
-import net.minecraft.client.renderer.entity.RenderPlayer;
+import baubles.api.render.IRenderBauble.RenderType;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
 public interface IRenderObject {
 
-	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale);
+	public void onRenderObject(ItemStack stack, EntityPlayer player, boolean isSlim, float partialTicks, float scale);
+
+	public RenderType getRenderType();
 
 }

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemAmuletCross.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemAmuletCross.java
@@ -8,7 +8,6 @@ import cursedflames.bountifulbaubles.util.ItemUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
@@ -20,8 +19,10 @@ import vazkii.botania.api.item.IPhantomInkable;
 
 public class ItemAmuletCross extends AGenericItemBauble implements IRenderBauble, IPhantomInkable {
 	public static final int RESIST_TIME = 36;
-	public static final ResourceLocation texture = new ResourceLocation(BountifulBaubles.MODID,
-			BountifulBaubles.ARMOR_TEXTURE_PATH+"amulet_cross.png");
+	public static final ResourceLocation texture = new ResourceLocation(
+			BountifulBaubles.MODID,
+			BountifulBaubles.ARMOR_TEXTURE_PATH + "amulet_cross.png"
+	);
 	@SideOnly(Side.CLIENT)
 	private static ModelBiped model;
 
@@ -49,48 +50,51 @@ public class ItemAmuletCross extends AGenericItemBauble implements IRenderBauble
 	@Override
 	public void onPlayerBaubleRender(ItemStack stack, EntityPlayer player, RenderType type,
 			float partialTicks) {
-//		if (type!=RenderType.BODY)
-//			return;
-//		if (stack.getItem() instanceof IPhantomInkable
-//				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
-//			return;
-//		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
-//
-//		Helper.rotateIfSneaking(player);
-////		GlStateManager.translate(0F, 0.2F, 0F);
-//
-//		float s = 1.14F/16F;
-//		GlStateManager.scale(s, s, s);
-//		if (model==null)
-//			model = new ModelBiped();
-//
-//		model.bipedBody.render(1);
+		//		if (type!=RenderType.BODY)
+		//			return;
+		//		if (stack.getItem() instanceof IPhantomInkable
+		//				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
+		//			return;
+		//		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
+		//
+		//		Helper.rotateIfSneaking(player);
+		////		GlStateManager.translate(0F, 0.2F, 0F);
+		//
+		//		float s = 1.14F/16F;
+		//		GlStateManager.scale(s, s, s);
+		//		if (model==null)
+		//			model = new ModelBiped();
+		//
+		//		model.bipedBody.render(1);
 	}
-	
+
 	@Override
-	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
-		if (stack.getItem() instanceof IPhantomInkable
-				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
+	public void onRenderObject(ItemStack stack, EntityPlayer player, boolean isSlim, float partialTicks, float scale) {
+		if ((stack.getItem() instanceof IPhantomInkable)
+				&& ((IPhantomInkable) stack.getItem()).hasPhantomInk(stack)) {
 			return;
-		if (player.isSneaking()) {
-			GlStateManager.translate(0, 0.2, 0);
 		}
-		renderer.getMainModel().bipedBody.postRender(scale);
 		if (player.hasItemInSlot(EntityEquipmentSlot.CHEST)) {
 			GlStateManager.translate(0.0F, -0.02F, -0.045F);
 			GlStateManager.scale(1.1F, 1.1F, 1.1F);
 		}
 		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
 
-//		Helper.rotateIfSneaking(player);
-//		GlStateManager.translate(0F, 0.2F, 0F);
+		//		Helper.rotateIfSneaking(player);
+		//		GlStateManager.translate(0F, 0.2F, 0F);
 
-		float s = 1.14F/16F;
+		final float s = 1.14F / 16F;
 		GlStateManager.scale(s, s, s);
-		if (model==null)
+		if (model == null) {
 			model = new ModelBiped();
+		}
 
 		model.bipedBody.render(1);
+	}
+
+	@Override
+	public RenderType getRenderType() {
+		return RenderType.BODY;
 	}
 
 	@Override

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemAmuletCross.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemAmuletCross.java
@@ -8,8 +8,10 @@ import cursedflames.bountifulbaubles.util.ItemUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
@@ -47,14 +49,40 @@ public class ItemAmuletCross extends AGenericItemBauble implements IRenderBauble
 	@Override
 	public void onPlayerBaubleRender(ItemStack stack, EntityPlayer player, RenderType type,
 			float partialTicks) {
-		if (type!=RenderType.BODY)
-			return;
+//		if (type!=RenderType.BODY)
+//			return;
+//		if (stack.getItem() instanceof IPhantomInkable
+//				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
+//			return;
+//		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
+//
+//		Helper.rotateIfSneaking(player);
+////		GlStateManager.translate(0F, 0.2F, 0F);
+//
+//		float s = 1.14F/16F;
+//		GlStateManager.scale(s, s, s);
+//		if (model==null)
+//			model = new ModelBiped();
+//
+//		model.bipedBody.render(1);
+	}
+	
+	@Override
+	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
 		if (stack.getItem() instanceof IPhantomInkable
 				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
 			return;
+		if (player.isSneaking()) {
+			GlStateManager.translate(0, 0.2, 0);
+		}
+		renderer.getMainModel().bipedBody.postRender(scale);
+		if (player.hasItemInSlot(EntityEquipmentSlot.CHEST)) {
+			GlStateManager.translate(0.0F, -0.02F, -0.045F);
+			GlStateManager.scale(1.1F, 1.1F, 1.1F);
+		}
 		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
 
-		Helper.rotateIfSneaking(player);
+//		Helper.rotateIfSneaking(player);
 //		GlStateManager.translate(0F, 0.2F, 0F);
 
 		float s = 1.14F/16F;

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemAmuletSin.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemAmuletSin.java
@@ -9,7 +9,9 @@ import cursedflames.bountifulbaubles.util.ItemUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.ResourceLocation;
@@ -50,14 +52,40 @@ public class ItemAmuletSin extends AGenericItemBauble implements IRenderBauble, 
 	@Override
 	public void onPlayerBaubleRender(ItemStack stack, EntityPlayer player, RenderType type,
 			float partialTicks) {
-		if (type!=RenderType.BODY)
-			return;
+//		if (type!=RenderType.BODY)
+//			return;
+//		if (stack.getItem() instanceof IPhantomInkable
+//				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
+//			return;
+//		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
+//
+//		Helper.rotateIfSneaking(player);
+////		GlStateManager.translate(0F, 0.2F, 0F);
+//
+//		float s = 1.14F/16F;
+//		GlStateManager.scale(s, s, s);
+//		if (model==null)
+//			model = new ModelBiped();
+//
+//		model.bipedBody.render(1);
+	}
+	
+	@Override
+	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
 		if (stack.getItem() instanceof IPhantomInkable
 				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
 			return;
+		if (player.isSneaking()) {
+			GlStateManager.translate(0, 0.2, 0);
+		}
+		renderer.getMainModel().bipedBody.postRender(scale);
+		if (player.hasItemInSlot(EntityEquipmentSlot.CHEST)) {
+			GlStateManager.translate(0.0F, -0.02F, -0.045F);
+			GlStateManager.scale(1.1F, 1.1F, 1.1F);
+		}
 		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
 
-		Helper.rotateIfSneaking(player);
+//		Helper.rotateIfSneaking(player);
 //		GlStateManager.translate(0F, 0.2F, 0F);
 
 		float s = 1.14F/16F;

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemAmuletSin.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemAmuletSin.java
@@ -9,7 +9,6 @@ import cursedflames.bountifulbaubles.util.ItemUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
@@ -22,8 +21,10 @@ import vazkii.botania.api.item.IPhantomInkable;
 public class ItemAmuletSin extends AGenericItemBauble implements IRenderBauble, IPhantomInkable {
 	public ItemAmuletSin(String name, String textureName) {
 		super(name, BountifulBaubles.TAB);
-		texture = new ResourceLocation(BountifulBaubles.MODID,
-				BountifulBaubles.ARMOR_TEXTURE_PATH+textureName+".png");
+		texture = new ResourceLocation(
+				BountifulBaubles.MODID,
+				BountifulBaubles.ARMOR_TEXTURE_PATH + textureName + ".png"
+		);
 	}
 
 	public final ResourceLocation texture;
@@ -52,47 +53,50 @@ public class ItemAmuletSin extends AGenericItemBauble implements IRenderBauble, 
 	@Override
 	public void onPlayerBaubleRender(ItemStack stack, EntityPlayer player, RenderType type,
 			float partialTicks) {
-//		if (type!=RenderType.BODY)
-//			return;
-//		if (stack.getItem() instanceof IPhantomInkable
-//				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
-//			return;
-//		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
-//
-//		Helper.rotateIfSneaking(player);
-////		GlStateManager.translate(0F, 0.2F, 0F);
-//
-//		float s = 1.14F/16F;
-//		GlStateManager.scale(s, s, s);
-//		if (model==null)
-//			model = new ModelBiped();
-//
-//		model.bipedBody.render(1);
+		//		if (type!=RenderType.BODY)
+		//			return;
+		//		if (stack.getItem() instanceof IPhantomInkable
+		//				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
+		//			return;
+		//		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
+		//
+		//		Helper.rotateIfSneaking(player);
+		////		GlStateManager.translate(0F, 0.2F, 0F);
+		//
+		//		float s = 1.14F/16F;
+		//		GlStateManager.scale(s, s, s);
+		//		if (model==null)
+		//			model = new ModelBiped();
+		//
+		//		model.bipedBody.render(1);
 	}
-	
+
 	@Override
-	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
-		if (stack.getItem() instanceof IPhantomInkable
-				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
+	public void onRenderObject(ItemStack stack, EntityPlayer player, boolean isSlim, float partialTicks, float scale) {
+		if ((stack.getItem() instanceof IPhantomInkable)
+				&& ((IPhantomInkable) stack.getItem()).hasPhantomInk(stack)) {
 			return;
-		if (player.isSneaking()) {
-			GlStateManager.translate(0, 0.2, 0);
 		}
-		renderer.getMainModel().bipedBody.postRender(scale);
 		if (player.hasItemInSlot(EntityEquipmentSlot.CHEST)) {
 			GlStateManager.translate(0.0F, -0.02F, -0.045F);
 			GlStateManager.scale(1.1F, 1.1F, 1.1F);
 		}
 		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
 
-//		Helper.rotateIfSneaking(player);
-//		GlStateManager.translate(0F, 0.2F, 0F);
+		//		Helper.rotateIfSneaking(player);
+		//		GlStateManager.translate(0F, 0.2F, 0F);
 
-		float s = 1.14F/16F;
+		final float s = 1.14F / 16F;
 		GlStateManager.scale(s, s, s);
-		if (model==null)
+		if (model == null) {
 			model = new ModelBiped();
+		}
 
 		model.bipedBody.render(1);
+	}
+
+	@Override
+	public RenderType getRenderType() {
+		return RenderType.BODY;
 	}
 }

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemFlareGun.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemFlareGun.java
@@ -86,7 +86,7 @@ public class ItemFlareGun extends GenericItemBB {
 			ITooltipFlag flagIn) {
 		super.addInformation(stack, worldIn, tooltip, flagIn);
 		if (!BountifulBaubles.isAlbedoLoaded) {
-			tooltip.add(BountifulBaubles.proxy.translate(getUnlocalizedName()+".tooltip.noalbedo"));
+			tooltip.add(BountifulBaubles.proxy.translate(getTranslationKey()+".tooltip.noalbedo"));
 		}
 	}
 }

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemMagicMirror.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemMagicMirror.java
@@ -62,7 +62,7 @@ public class ItemMagicMirror extends GenericItemBB implements ICustomEnchantColo
 		int dim = player.getSpawnDimension();
 		if (world.provider.getDimension()!=dim&&!interdimensional.getBoolean(false)) {
 			player.sendStatusMessage(new TextComponentTranslation(
-					ModItems.magicMirror.getUnlocalizedName()+".wrongdim"), true);
+					ModItems.magicMirror.getTranslationKey()+".wrongdim"), true);
 			return new ActionResult<ItemStack>(EnumActionResult.FAIL, player.getHeldItem(hand));
 		}
 		player.setActiveHand(hand);

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemModifierBook.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemModifierBook.java
@@ -41,7 +41,7 @@ public class ItemModifierBook extends GenericItemBB implements ICustomEnchantCol
 
 	@Override
 	public String getItemStackDisplayName(ItemStack stack) {
-		return BountifulBaubles.proxy.translate(getUnlocalizedName()+"."
+		return BountifulBaubles.proxy.translate(getTranslationKey()+"."
 				+(stack.hasTagCompound()&&stack.getTagCompound().hasKey("baubleModifier")
 						? stack.getTagCompound().getString("baubleModifier")
 						: EnumBaubleModifier.NONE.name)

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemPotionRecall.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemPotionRecall.java
@@ -27,7 +27,7 @@ public class ItemPotionRecall extends GenericItemBB {
 		if (world.provider.getDimension()!=dim
 				&&!ItemMagicMirror.interdimensional.getBoolean(false)) {
 			player.sendStatusMessage(new TextComponentTranslation(
-					ModItems.magicMirror.getUnlocalizedName()+".wrongdim"), true);
+					ModItems.magicMirror.getTranslationKey()+".wrongdim"), true);
 			return new ActionResult<ItemStack>(EnumActionResult.FAIL, player.getHeldItem(hand));
 		}
 		player.setActiveHand(hand);

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemPotionWormhole.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemPotionWormhole.java
@@ -33,7 +33,7 @@ public class ItemPotionWormhole extends GenericItemBB {
 			EnumHand hand) {
 		if (world.playerEntities.size()<2) {
 			player.sendStatusMessage(new TextComponentTranslation(
-					ModItems.potionWormhole.getUnlocalizedName()+".nootherplayers"), true);
+					ModItems.potionWormhole.getTranslationKey()+".nootherplayers"), true);
 			return new ActionResult<ItemStack>(EnumActionResult.FAIL, player.getHeldItem(hand));
 		}
 //		if (world.playerEntities.size()>-1) {
@@ -77,7 +77,7 @@ public class ItemPotionWormhole extends GenericItemBB {
 	public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip,
 			ITooltipFlag flagIn) {
 		super.addInformation(stack, worldIn, tooltip, flagIn);
-		String base = getUnlocalizedName()+".tooltip.";
+		String base = getTranslationKey()+".tooltip.";
 		if (Minecraft.getMinecraft().isSingleplayer()) {
 			tooltip.add(I18n.translateToLocal(base+"sp"));
 		} else {

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemShieldCobalt.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemShieldCobalt.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.annotation.Nullable;
-
 import com.google.common.collect.Multimap;
 
 import baubles.api.BaubleType;
@@ -16,12 +14,11 @@ import cursedflames.bountifulbaubles.BountifulBaubles;
 import cursedflames.bountifulbaubles.baubleeffect.BaubleAttributeModifierHandler;
 import cursedflames.bountifulbaubles.client.layer.IRenderObject;
 import cursedflames.bountifulbaubles.item.base.IItemAttributeModifier;
+import javax.annotation.Nullable;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
-import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
@@ -43,7 +40,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -59,33 +55,37 @@ public class ItemShieldCobalt extends ItemShield
 	private static final Map<IAttribute, AttributeModifier> modMap = new HashMap<>();
 
 	static {
-		modMap.put(SharedMonsterAttributes.KNOCKBACK_RESISTANCE,
-				new AttributeModifier(KNOCKBACK_RESISTANCE_BAUBLE_UUID,
-						"Cobalt Shield (bauble slot) knockback resistance", 10, 0));
+		modMap.put(
+				SharedMonsterAttributes.KNOCKBACK_RESISTANCE,
+				new AttributeModifier(
+						KNOCKBACK_RESISTANCE_BAUBLE_UUID,
+						"Cobalt Shield (bauble slot) knockback resistance", 10, 0
+				)
+		);
 	}
 
 	public ItemShieldCobalt(String name) {
 		super();
-		setRegistryName(name);
-		setTranslationKey(BountifulBaubles.MODID+"."+name);
-		setCreativeTab(BountifulBaubles.TAB);
-		setMaxDamage(336*3);
+		this.setRegistryName(name);
+		this.setTranslationKey(BountifulBaubles.MODID + "." + name);
+		this.setCreativeTab(BountifulBaubles.TAB);
+		this.setMaxDamage(336 * 3);
 		BountifulBaubles.registryHelper.addItemModel(this);
 	}
 
 	public static boolean isUsable(ItemStack stack) {
-		return stack.getItemDamage()<stack.getMaxDamage();
+		return stack.getItemDamage() < stack.getMaxDamage();
 	}
 
 	@Override
 	public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn,
 			EnumHand handIn) {
-		ItemStack itemstack = playerIn.getHeldItem(handIn);
+		final ItemStack itemstack = playerIn.getHeldItem(handIn);
 		if (isUsable(itemstack)) {
 			playerIn.setActiveHand(handIn);
-			return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, itemstack);
+			return new ActionResult<>(EnumActionResult.SUCCESS, itemstack);
 		} else {
-			return new ActionResult<ItemStack>(EnumActionResult.FAIL, itemstack);
+			return new ActionResult<>(EnumActionResult.FAIL, itemstack);
 		}
 	}
 
@@ -93,7 +93,7 @@ public class ItemShieldCobalt extends ItemShield
 	public boolean getIsRepairable(ItemStack toRepair, ItemStack repair) {
 		// TODO oredictionary support, because hardcore ores is stupid and adds
 		// its own iron
-		return repair.getItem()==Items.IRON_INGOT;
+		return repair.getItem() == Items.IRON_INGOT;
 	}
 
 	@SubscribeEvent
@@ -102,29 +102,31 @@ public class ItemShieldCobalt extends ItemShield
 		if (!(event.getEntityLiving() instanceof EntityPlayer)) {
 			return;
 		}
-		EntityPlayer player = (EntityPlayer) event.getEntityLiving();
-		if (player.getActiveItemStack()==null) {
+		final EntityPlayer player = (EntityPlayer) event.getEntityLiving();
+		if (player.getActiveItemStack() == null) {
 			return;
 		}
 		// System.out.println("player holding item");
 		ItemStack stack = player.getActiveItemStack();
-		float damage = event.getAmount();
-		if (damage>5.0F&&stack!=null&&stack.getItem() instanceof ItemShieldCobalt) {
+		final float damage = event.getAmount();
+		if ((damage > 5.0F) && (stack != null) && (stack.getItem() instanceof ItemShieldCobalt)) {
 			// System.out.println("damaging shield...");
 			// so it never damages to the point of being destroyed
-			int i = Math.min(1+(int) damage, stack.getMaxDamage()-stack.getItemDamage());
+			final int i = Math.min(1 + (int) damage, stack.getMaxDamage() - stack.getItemDamage());
 
 			stack.damageItem(i, player);
 
 			// shouldn't get destroyed, but just in case, don't want to cause a
 			// crash
-			if (stack.isEmpty()||stack.getItemDamage()>=stack.getMaxDamage()) {
+			if (stack.isEmpty() || (stack.getItemDamage() >= stack.getMaxDamage())) {
 				if (stack.isEmpty()) {
-					EnumHand enumhand = player.getActiveHand();
-					net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(player, stack,
-							enumhand);
+					final EnumHand enumhand = player.getActiveHand();
+					net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(
+							player, stack,
+							enumhand
+					);
 
-					if (enumhand==EnumHand.MAIN_HAND) {
+					if (enumhand == EnumHand.MAIN_HAND) {
 						player.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, (ItemStack) null);
 					} else {
 						player.setItemStackToSlot(EntityEquipmentSlot.OFFHAND, (ItemStack) null);
@@ -136,9 +138,11 @@ public class ItemShieldCobalt extends ItemShield
 				// TODO metal sound instead of wood sound?
 				// TODO find a good volume for this
 				// TODO what category should this be?
-				player.world.playSound(null, player.posX,  player.posY,  player.posZ,
+				player.world.playSound(
+						null, player.posX, player.posY, player.posZ,
 						SoundEvents.ITEM_SHIELD_BREAK, SoundCategory.PLAYERS,
-						0.9f, 0.8F+player.world.rand.nextFloat()*0.4F);
+						0.9f, 0.8F + (player.world.rand.nextFloat() * 0.4F)
+				);
 			}
 		}
 	}
@@ -159,14 +163,14 @@ public class ItemShieldCobalt extends ItemShield
 	}
 
 	private static void resetRepairValue(ItemStack stack) {
-		if (!stack.isEmpty()&&stack.getItem() instanceof ItemShieldCobalt&&stack.hasTagCompound()) {
+		if (!stack.isEmpty() && (stack.getItem() instanceof ItemShieldCobalt) && stack.hasTagCompound()) {
 			stack.getTagCompound().removeTag("RepairCost");
 		}
 	}
 
 	@Override
 	public String getItemStackDisplayName(ItemStack stack) {
-		return BountifulBaubles.proxy.translate(getTranslationKey()+".name");
+		return BountifulBaubles.proxy.translate(this.getTranslationKey() + ".name");
 	}
 
 	@Override
@@ -180,31 +184,38 @@ public class ItemShieldCobalt extends ItemShield
 			// hides "+10 knockback resist"
 			stack.getTagCompound().setInteger("HideFlags", 2);
 		}
-		if (stack.getItemDamage()>=stack.getMaxDamage()) {
-			tooltip.add(I18n.translateToLocal(BountifulBaubles.MODID+".broken"));
+		if (stack.getItemDamage() >= stack.getMaxDamage()) {
+			tooltip.add(I18n.translateToLocal(BountifulBaubles.MODID + ".broken"));
 		}
-		tooltip.add(I18n.translateToLocal(getTranslationKey()+".tooltip.0"));
+		tooltip.add(I18n.translateToLocal(this.getTranslationKey() + ".tooltip.0"));
 		if (GuiScreen.isShiftKeyDown()) {
-			tooltip.add(I18n.translateToLocal(getTranslationKey()+".tooltip.1"));
-			tooltip.add(I18n.translateToLocal(getTranslationKey()+".tooltip.2"));
-			if (stack.getItem() instanceof IPhantomInkable
-					&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack)) {
-				tooltip.add(BountifulBaubles.proxy
-						.translate(BountifulBaubles.MODID+".misc.hasPhantomInk"));
+			tooltip.add(I18n.translateToLocal(this.getTranslationKey() + ".tooltip.1"));
+			tooltip.add(I18n.translateToLocal(this.getTranslationKey() + ".tooltip.2"));
+			if ((stack.getItem() instanceof IPhantomInkable)
+					&& ((IPhantomInkable) stack.getItem()).hasPhantomInk(stack)) {
+				tooltip.add(
+						BountifulBaubles.proxy
+								.translate(BountifulBaubles.MODID + ".misc.hasPhantomInk")
+				);
 			}
-		} else
-			tooltip.add(I18n.translateToLocal(BountifulBaubles.MODID+".moreinfo"));
+		} else {
+			tooltip.add(I18n.translateToLocal(BountifulBaubles.MODID + ".moreinfo"));
+		}
 
 	}
 
 	@Override
 	public Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot slot,
 			ItemStack stack) {
-		Multimap<String, AttributeModifier> mods = super.getAttributeModifiers(slot, stack);
-		if (slot==EntityEquipmentSlot.MAINHAND||slot==EntityEquipmentSlot.OFFHAND) {
-			String knockback = SharedMonsterAttributes.KNOCKBACK_RESISTANCE.getName();
-			mods.put(knockback, new AttributeModifier(KNOCKBACK_RESISTANCE_UUID,
-					"Cobalt Shield knockback resistance", 10, 0));
+		final Multimap<String, AttributeModifier> mods = super.getAttributeModifiers(slot, stack);
+		if ((slot == EntityEquipmentSlot.MAINHAND) || (slot == EntityEquipmentSlot.OFFHAND)) {
+			final String knockback = SharedMonsterAttributes.KNOCKBACK_RESISTANCE.getName();
+			mods.put(
+					knockback, new AttributeModifier(
+							KNOCKBACK_RESISTANCE_UUID,
+							"Cobalt Shield knockback resistance", 10, 0
+					)
+			);
 		}
 		return mods;
 	}
@@ -232,32 +243,36 @@ public class ItemShieldCobalt extends ItemShield
 	@Override
 	public void onPlayerBaubleRender(ItemStack stack, EntityPlayer player, RenderType type,
 			float partialTicks) {
-//		if (type==RenderType.BODY) {
-//			Helper.rotateIfSneaking(player);
-//			boolean armor = !player.getItemStackFromSlot(EntityEquipmentSlot.CHEST).isEmpty();
-//			GlStateManager.scale(0.6, 0.6, 0.6);
-//			GlStateManager.rotate(180, 0, 0, 1);
-//			GlStateManager.translate(0.5, -0.25, armor ? 0.75 : 0.7);
-//			Minecraft.getMinecraft().getRenderItem().renderItem(stack,
-//					ItemCameraTransforms.TransformType.NONE);
-//		}
+		//		if (type==RenderType.BODY) {
+		//			Helper.rotateIfSneaking(player);
+		//			boolean armor = !player.getItemStackFromSlot(EntityEquipmentSlot.CHEST).isEmpty();
+		//			GlStateManager.scale(0.6, 0.6, 0.6);
+		//			GlStateManager.rotate(180, 0, 0, 1);
+		//			GlStateManager.translate(0.5, -0.25, armor ? 0.75 : 0.7);
+		//			Minecraft.getMinecraft().getRenderItem().renderItem(stack,
+		//					ItemCameraTransforms.TransformType.NONE);
+		//		}
 	}
-	
+
 	@Override
-	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
-		if (player.isSneaking()) {
-			GlStateManager.translate(0, 0.2, 0);
-		}
-		renderer.getMainModel().bipedBody.postRender(scale);
-//		if (player.hasItemInSlot(EntityEquipmentSlot.CHEST)) {
-//			GlStateManager.translate(0.0F, -0.02F, -0.045F);
-//			GlStateManager.scale(1.1F, 1.1F, 1.1F);
-//		}
-		boolean armor = !player.getItemStackFromSlot(EntityEquipmentSlot.CHEST).isEmpty();
+	@SideOnly(Side.CLIENT)
+	public void onRenderObject(ItemStack stack, EntityPlayer player, boolean isSlim, float partialTicks, float scale) {
+		//		if (player.hasItemInSlot(EntityEquipmentSlot.CHEST)) {
+		//			GlStateManager.translate(0.0F, -0.02F, -0.045F);
+		//			GlStateManager.scale(1.1F, 1.1F, 1.1F);
+		//		}
+		final boolean armor = !player.getItemStackFromSlot(EntityEquipmentSlot.CHEST).isEmpty();
 		GlStateManager.scale(0.6, 0.6, 0.6);
 		GlStateManager.rotate(180, 0, 0, 1);
 		GlStateManager.translate(0.5, -0.25, armor ? 0.75 : 0.7);
-		Minecraft.getMinecraft().getRenderItem().renderItem(stack,
-				ItemCameraTransforms.TransformType.NONE);
+		Minecraft.getMinecraft().getRenderItem().renderItem(
+				stack,
+				ItemCameraTransforms.TransformType.NONE
+		);
+	}
+
+	@Override
+	public RenderType getRenderType() {
+		return RenderType.BODY;
 	}
 }

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemShieldCobalt.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemShieldCobalt.java
@@ -14,11 +14,14 @@ import baubles.api.IBauble;
 import baubles.api.render.IRenderBauble;
 import cursedflames.bountifulbaubles.BountifulBaubles;
 import cursedflames.bountifulbaubles.baubleeffect.BaubleAttributeModifierHandler;
+import cursedflames.bountifulbaubles.client.layer.IRenderObject;
 import cursedflames.bountifulbaubles.item.base.IItemAttributeModifier;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
@@ -48,7 +51,7 @@ import vazkii.botania.api.item.IPhantomInkable;
 
 @SuppressWarnings("deprecation")
 public class ItemShieldCobalt extends ItemShield
-		implements IBauble, IRenderBauble, IItemAttributeModifier {
+		implements IBauble, IRenderBauble, IItemAttributeModifier, IRenderObject {
 	public static final UUID KNOCKBACK_RESISTANCE_UUID = UUID
 			.fromString("418ed1da-15ae-4c7b-ac5e-4807ca52ffe3");
 	public static final UUID KNOCKBACK_RESISTANCE_BAUBLE_UUID = UUID
@@ -64,7 +67,7 @@ public class ItemShieldCobalt extends ItemShield
 	public ItemShieldCobalt(String name) {
 		super();
 		setRegistryName(name);
-		setUnlocalizedName(BountifulBaubles.MODID+"."+name);
+		setTranslationKey(BountifulBaubles.MODID+"."+name);
 		setCreativeTab(BountifulBaubles.TAB);
 		setMaxDamage(336*3);
 		BountifulBaubles.registryHelper.addItemModel(this);
@@ -163,7 +166,7 @@ public class ItemShieldCobalt extends ItemShield
 
 	@Override
 	public String getItemStackDisplayName(ItemStack stack) {
-		return BountifulBaubles.proxy.translate(getUnlocalizedName()+".name");
+		return BountifulBaubles.proxy.translate(getTranslationKey()+".name");
 	}
 
 	@Override
@@ -180,10 +183,10 @@ public class ItemShieldCobalt extends ItemShield
 		if (stack.getItemDamage()>=stack.getMaxDamage()) {
 			tooltip.add(I18n.translateToLocal(BountifulBaubles.MODID+".broken"));
 		}
-		tooltip.add(I18n.translateToLocal(getUnlocalizedName()+".tooltip.0"));
+		tooltip.add(I18n.translateToLocal(getTranslationKey()+".tooltip.0"));
 		if (GuiScreen.isShiftKeyDown()) {
-			tooltip.add(I18n.translateToLocal(getUnlocalizedName()+".tooltip.1"));
-			tooltip.add(I18n.translateToLocal(getUnlocalizedName()+".tooltip.2"));
+			tooltip.add(I18n.translateToLocal(getTranslationKey()+".tooltip.1"));
+			tooltip.add(I18n.translateToLocal(getTranslationKey()+".tooltip.2"));
 			if (stack.getItem() instanceof IPhantomInkable
 					&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack)) {
 				tooltip.add(BountifulBaubles.proxy
@@ -229,14 +232,32 @@ public class ItemShieldCobalt extends ItemShield
 	@Override
 	public void onPlayerBaubleRender(ItemStack stack, EntityPlayer player, RenderType type,
 			float partialTicks) {
-		if (type==RenderType.BODY) {
-			Helper.rotateIfSneaking(player);
-			boolean armor = !player.getItemStackFromSlot(EntityEquipmentSlot.CHEST).isEmpty();
-			GlStateManager.scale(0.6, 0.6, 0.6);
-			GlStateManager.rotate(180, 0, 0, 1);
-			GlStateManager.translate(0.5, -0.25, armor ? 0.75 : 0.7);
-			Minecraft.getMinecraft().getRenderItem().renderItem(stack,
-					ItemCameraTransforms.TransformType.NONE);
+//		if (type==RenderType.BODY) {
+//			Helper.rotateIfSneaking(player);
+//			boolean armor = !player.getItemStackFromSlot(EntityEquipmentSlot.CHEST).isEmpty();
+//			GlStateManager.scale(0.6, 0.6, 0.6);
+//			GlStateManager.rotate(180, 0, 0, 1);
+//			GlStateManager.translate(0.5, -0.25, armor ? 0.75 : 0.7);
+//			Minecraft.getMinecraft().getRenderItem().renderItem(stack,
+//					ItemCameraTransforms.TransformType.NONE);
+//		}
+	}
+	
+	@Override
+	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
+		if (player.isSneaking()) {
+			GlStateManager.translate(0, 0.2, 0);
 		}
+		renderer.getMainModel().bipedBody.postRender(scale);
+//		if (player.hasItemInSlot(EntityEquipmentSlot.CHEST)) {
+//			GlStateManager.translate(0.0F, -0.02F, -0.045F);
+//			GlStateManager.scale(1.1F, 1.1F, 1.1F);
+//		}
+		boolean armor = !player.getItemStackFromSlot(EntityEquipmentSlot.CHEST).isEmpty();
+		GlStateManager.scale(0.6, 0.6, 0.6);
+		GlStateManager.rotate(180, 0, 0, 1);
+		GlStateManager.translate(0.5, -0.25, armor ? 0.75 : 0.7);
+		Minecraft.getMinecraft().getRenderItem().renderItem(stack,
+				ItemCameraTransforms.TransformType.NONE);
 	}
 }

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemSunglasses.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemSunglasses.java
@@ -133,14 +133,10 @@ public class ItemSunglasses extends ItemArmorBB
 	}
 	
 	@Override
-	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
+	public void onRenderObject(ItemStack stack, EntityPlayer player, boolean isSlim, float partialTicks, float scale) {
 		if (stack.getItem() instanceof IPhantomInkable
 				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
 			return;
-		if (player.isSneaking()) {
-			GlStateManager.translate(0, 0.2, 0);
-		}
-		renderer.getMainModel().bipedHead.postRender(scale);
 		if (player.hasItemInSlot(EntityEquipmentSlot.HEAD)) {
 			GlStateManager.translate(0.0F, -0.02F, -0.045F);
 			GlStateManager.scale(1.1F, 1.1F, 1.1F);
@@ -158,6 +154,10 @@ public class ItemSunglasses extends ItemArmorBB
 //		GlStateManager.rotate(-90F, 0F, 1F, 0F);
 		model.bipedHead.render(1.0F);
 		GlStateManager.popMatrix();
+	}
+	@Override
+	public RenderType getRenderType() {
+		return RenderType.HEAD;
 	}
 
 	@Override

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemSunglasses.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemSunglasses.java
@@ -11,10 +11,12 @@ import baubles.api.render.IRenderBauble;
 import cursedflames.bountifulbaubles.BountifulBaubles;
 import cursedflames.bountifulbaubles.baubleeffect.PotionNegation;
 import cursedflames.bountifulbaubles.baubleeffect.PotionNegation.IPotionNegateItem;
+import cursedflames.bountifulbaubles.client.layer.IRenderObject;
 import cursedflames.bountifulbaubles.item.armor.ItemArmorBB;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -30,7 +32,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.botania.api.item.IPhantomInkable;
 
 public class ItemSunglasses extends ItemArmorBB
-		implements IBauble/* , ICustomEnchantColor */, ISpecialArmor, IRenderBauble, IPotionNegateItem {
+		implements IBauble/* , ICustomEnchantColor */, ISpecialArmor, IRenderBauble, IPotionNegateItem, IRenderObject {
 	private static final ResourceLocation texture = new ResourceLocation(BountifulBaubles.MODID,
 			"textures/models/armor/sunglasses_layer_1.png");
 
@@ -108,12 +110,41 @@ public class ItemSunglasses extends ItemArmorBB
 	@SideOnly(Side.CLIENT)
 	public void onPlayerBaubleRender(ItemStack stack, EntityPlayer player, RenderType type,
 			float partialTicks) {
-		if (type!=RenderType.HEAD)
-			return;
+//		if (type!=RenderType.HEAD)
+//			return;
+//		if (stack.getItem() instanceof IPhantomInkable
+//				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
+//			return;
+//
+//		Minecraft.getMinecraft().renderEngine.bindTexture(getRenderTexture());
+//		GlStateManager.pushMatrix();
+//		GlStateManager.enableBlend();
+//
+//		ModelBiped model = BountifulBaubles.proxy.getArmorModel(modelName+"2");
+//		if (player.isSneaking())
+//			GlStateManager.translate(0.25F*MathHelper.sin(player.rotationPitch*(float) Math.PI/180),
+//					0.25F*MathHelper.cos(player.rotationPitch*(float) Math.PI/180), 0F);
+//		float s = 1F/16F;
+//		GlStateManager.scale(s, s, s);
+//		GlStateManager.rotate(-90F, 0F, 1F, 0F);
+//		model.bipedHead.render(1.0F);
+//
+//		GlStateManager.popMatrix();
+	}
+	
+	@Override
+	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
 		if (stack.getItem() instanceof IPhantomInkable
 				&&((IPhantomInkable) stack.getItem()).hasPhantomInk(stack))
 			return;
-
+		if (player.isSneaking()) {
+			GlStateManager.translate(0, 0.2, 0);
+		}
+		renderer.getMainModel().bipedHead.postRender(scale);
+		if (player.hasItemInSlot(EntityEquipmentSlot.HEAD)) {
+			GlStateManager.translate(0.0F, -0.02F, -0.045F);
+			GlStateManager.scale(1.1F, 1.1F, 1.1F);
+		}
 		Minecraft.getMinecraft().renderEngine.bindTexture(getRenderTexture());
 		GlStateManager.pushMatrix();
 		GlStateManager.enableBlend();
@@ -124,9 +155,8 @@ public class ItemSunglasses extends ItemArmorBB
 					0.25F*MathHelper.cos(player.rotationPitch*(float) Math.PI/180), 0F);
 		float s = 1F/16F;
 		GlStateManager.scale(s, s, s);
-		GlStateManager.rotate(-90F, 0F, 1F, 0F);
+//		GlStateManager.rotate(-90F, 0F, 1F, 0F);
 		model.bipedHead.render(1.0F);
-
 		GlStateManager.popMatrix();
 	}
 

--- a/src/main/java/cursedflames/bountifulbaubles/item/ItemWormholeMirror.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/ItemWormholeMirror.java
@@ -43,7 +43,7 @@ public class ItemWormholeMirror extends ItemMagicMirror {
 			int dim = player.getSpawnDimension();
 			if (world.provider.getDimension()!=dim&&!interdimensional.getBoolean(false)) {
 				player.sendStatusMessage(new TextComponentTranslation(
-						ModItems.magicMirror.getUnlocalizedName()+".wrongdim"), true);
+						ModItems.magicMirror.getTranslationKey()+".wrongdim"), true);
 			} else {
 				teleportPlayerToSpawn(world, player);
 			}
@@ -53,7 +53,7 @@ public class ItemWormholeMirror extends ItemMagicMirror {
 			if (world.playerEntities.size()<2) {
 				player.sendStatusMessage(
 						new TextComponentTranslation(
-								ModItems.potionWormhole.getUnlocalizedName()+".nootherplayers"),
+								ModItems.potionWormhole.getTranslationKey()+".nootherplayers"),
 						true);
 			} else {
 				player.openGui(BountifulBaubles.instance, ItemPotionWormhole.GUI_ID, world,

--- a/src/main/java/cursedflames/bountifulbaubles/item/armor/ItemArmorBB.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/armor/ItemArmorBB.java
@@ -34,7 +34,7 @@ public class ItemArmorBB extends ItemArmor implements IPhantomInkable {
 		super(material, 0, slot);
 		this.modelName = modelName;
 		setCreativeTab(tab);
-		setUnlocalizedName(BountifulBaubles.MODID+"."+name);
+		setTranslationKey(BountifulBaubles.MODID+"."+name);
 		setRegistryName(new ResourceLocation(BountifulBaubles.MODID, name));
 	}
 
@@ -64,7 +64,7 @@ public class ItemArmorBB extends ItemArmor implements IPhantomInkable {
 			ITooltipFlag flagIn) {
 		boolean isShifting = GuiScreen.isShiftKeyDown();
 		// TODO add proxies instead of being lazy and using deprecated I18n
-		String base = getUnlocalizedName()+".tooltip.";
+		String base = getTranslationKey()+".tooltip.";
 		String shift = "";
 		if (I18n.canTranslate(base+"0")) {
 			if (isShifting&&I18n.canTranslate(base+"0s")) {

--- a/src/main/java/cursedflames/bountifulbaubles/item/base/GenericItemBB.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/base/GenericItemBB.java
@@ -2,12 +2,11 @@ package cursedflames.bountifulbaubles.item.base;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import baubles.api.render.IRenderBauble.RenderType;
 import cursedflames.bountifulbaubles.BountifulBaubles;
 import cursedflames.bountifulbaubles.client.layer.IRenderObject;
+import javax.annotation.Nullable;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -19,9 +18,9 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class GenericItemBB extends Item implements IRenderObject{
-//	public Property creativeOnly;
-	
+public class GenericItemBB extends Item implements IRenderObject {
+	//	public Property creativeOnly;
+
 	public GenericItemBB(String name) {
 		this(name, null);
 	}
@@ -31,23 +30,23 @@ public class GenericItemBB extends Item implements IRenderObject{
 	}
 
 	public GenericItemBB(String name, CreativeTabs tab, boolean configCreativeOnly) {
-		setRegistryName(new ResourceLocation(BountifulBaubles.MODID, name));
-		setTranslationKey(BountifulBaubles.MODID+"."+name);
-		if (tab!=null) {
-			setCreativeTab(tab);
+		this.setRegistryName(new ResourceLocation(BountifulBaubles.MODID, name));
+		this.setTranslationKey(BountifulBaubles.MODID + "." + name);
+		if (tab != null) {
+			this.setCreativeTab(tab);
 		}
-//		if (configCreativeOnly) {
-//			Property unsynced = BountifulBaubles.config.addPropBoolean(
-//					getRegistryName()+".creativeOnly", "Items",
-//					"Whether or not "+getRegistryName()
-//							+" is creative only. If enabled, recipes and loot tables for this item will not be added, and the item will have a creative only tooltip added.",
-//					false, EnumPropSide.SYNCED);
-//			unsynced.setRequiresMcRestart(true);
-//			creativeOnly = BountifulBaubles.config
-//					.getSyncedProperty(getRegistryName()+".creativeOnly");
-//		} else {
-//			creativeOnly = null;
-//		}
+		//		if (configCreativeOnly) {
+		//			Property unsynced = BountifulBaubles.config.addPropBoolean(
+		//					getRegistryName()+".creativeOnly", "Items",
+		//					"Whether or not "+getRegistryName()
+		//							+" is creative only. If enabled, recipes and loot tables for this item will not be added, and the item will have a creative only tooltip added.",
+		//					false, EnumPropSide.SYNCED);
+		//			unsynced.setRequiresMcRestart(true);
+		//			creativeOnly = BountifulBaubles.config
+		//					.getSyncedProperty(getRegistryName()+".creativeOnly");
+		//		} else {
+		//			creativeOnly = null;
+		//		}
 	}
 
 	@SuppressWarnings("deprecation")
@@ -55,25 +54,31 @@ public class GenericItemBB extends Item implements IRenderObject{
 	@Override
 	public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip,
 			ITooltipFlag flagIn) {
-		boolean isShifting = GuiScreen.isShiftKeyDown();
+		final boolean isShifting = GuiScreen.isShiftKeyDown();
 		// TODO add proxies instead of being lazy and using deprecated I18n
-		String base = getTranslationKey()+".tooltip.";
+		final String base = this.getTranslationKey() + ".tooltip.";
 		String shift = "";
-		if (I18n.canTranslate(base+"0")) {
-			if (isShifting&&I18n.canTranslate(base+"0s")) {
+		if (I18n.canTranslate(base + "0")) {
+			if (isShifting && I18n.canTranslate(base + "0s")) {
 				shift = "s";
 			}
-			for (int i = 0; I18n.canTranslate(base+i+shift)&&i<100; i++) {
-				tooltip.add(I18n.translateToLocal(base+i+shift));
+			for (int i = 0; I18n.canTranslate(base + i + shift) && (i < 100); i++) {
+				tooltip.add(I18n.translateToLocal(base + i + shift));
 			}
 		}
-//		if (creativeOnly!=null&&creativeOnly.getBoolean()) {
-//			tooltip.add(BountifulBaubles.proxy.translate(BountifulBaubles.MODID+".creativeonly"));
-//		}
+		//		if (creativeOnly!=null&&creativeOnly.getBoolean()) {
+		//			tooltip.add(BountifulBaubles.proxy.translate(BountifulBaubles.MODID+".creativeonly"));
+		//		}
 	}
 
 	@Override
-	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
-		
+	@SideOnly(Side.CLIENT)
+	public void onRenderObject(ItemStack stack, EntityPlayer player, boolean isSlim, float partialTicks, float scale) {
+
+	}
+
+	@Override
+	public RenderType getRenderType() {
+		return null;
 	}
 }

--- a/src/main/java/cursedflames/bountifulbaubles/item/base/GenericItemBB.java
+++ b/src/main/java/cursedflames/bountifulbaubles/item/base/GenericItemBB.java
@@ -5,9 +5,12 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import cursedflames.bountifulbaubles.BountifulBaubles;
+import cursedflames.bountifulbaubles.client.layer.IRenderObject;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -16,7 +19,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class GenericItemBB extends Item {
+public class GenericItemBB extends Item implements IRenderObject{
 //	public Property creativeOnly;
 	
 	public GenericItemBB(String name) {
@@ -29,7 +32,7 @@ public class GenericItemBB extends Item {
 
 	public GenericItemBB(String name, CreativeTabs tab, boolean configCreativeOnly) {
 		setRegistryName(new ResourceLocation(BountifulBaubles.MODID, name));
-		setUnlocalizedName(BountifulBaubles.MODID+"."+name);
+		setTranslationKey(BountifulBaubles.MODID+"."+name);
 		if (tab!=null) {
 			setCreativeTab(tab);
 		}
@@ -54,7 +57,7 @@ public class GenericItemBB extends Item {
 			ITooltipFlag flagIn) {
 		boolean isShifting = GuiScreen.isShiftKeyDown();
 		// TODO add proxies instead of being lazy and using deprecated I18n
-		String base = getUnlocalizedName()+".tooltip.";
+		String base = getTranslationKey()+".tooltip.";
 		String shift = "";
 		if (I18n.canTranslate(base+"0")) {
 			if (isShifting&&I18n.canTranslate(base+"0s")) {
@@ -67,5 +70,10 @@ public class GenericItemBB extends Item {
 //		if (creativeOnly!=null&&creativeOnly.getBoolean()) {
 //			tooltip.add(BountifulBaubles.proxy.translate(BountifulBaubles.MODID+".creativeonly"));
 //		}
+	}
+
+	@Override
+	public void onRenderObject(ItemStack stack, EntityPlayer player, RenderPlayer renderer, boolean isSlim, float partialTicks, float scale) {
+		
 	}
 }

--- a/src/main/java/cursedflames/bountifulbaubles/proxy/ClientProxy.java
+++ b/src/main/java/cursedflames/bountifulbaubles/proxy/ClientProxy.java
@@ -1,5 +1,9 @@
 package cursedflames.bountifulbaubles.proxy;
 
+import java.util.Map;
+import java.util.Map.Entry;
+
+import cursedflames.bountifulbaubles.client.layer.BountfulRenderLayer;
 import cursedflames.bountifulbaubles.client.model.ModelCrownGold;
 import cursedflames.bountifulbaubles.client.model.ModelSunglasses;
 import cursedflames.bountifulbaubles.client.particle.ParticleGradient;
@@ -9,12 +13,15 @@ import cursedflames.bountifulbaubles.entity.ThrowableAdvancedRenderFactory;
 import cursedflames.bountifulbaubles.entity.ThrowableDefaultRenderFactory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBiped;
+import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class ClientProxy implements ISideProxy {
 	@Override
@@ -45,8 +52,12 @@ public class ClientProxy implements ISideProxy {
 	public void spawnParticleGradient(World world, double x, double y, double z, float r, float g,
 			float b, float rT, float gT, float bT, int maxAge, double velX, double velY,
 			double velZ) {
-		Minecraft.getMinecraft().effectRenderer.addEffect(new ParticleGradient(world, x, y, z, r, g,
-				b, rT, gT, bT, maxAge, velX, velY, velZ));
+		Minecraft.getMinecraft().effectRenderer.addEffect(
+				new ParticleGradient(
+						world, x, y, z, r, g,
+						b, rT, gT, bT, maxAge, velX, velY, velZ
+				)
+		);
 	}
 
 	private static final ModelCrownGold modelCrownGold = new ModelCrownGold();
@@ -55,30 +66,52 @@ public class ClientProxy implements ISideProxy {
 
 	@Override
 	public ModelBiped getArmorModel(String modelName) {
-		if (modelName.equals("crownGold"))
+		if (modelName.equals("crownGold")) {
 			return modelCrownGold;
-		else if (modelName.equals("sunglasses1"))
+		} else if (modelName.equals("sunglasses1")) {
 			return modelSunglasses1;
-		else if (modelName.equals("sunglasses2"))
+		} else if (modelName.equals("sunglasses2")) {
 			return modelSunglasses2;
+		}
 		return null;
 	}
 
 	@Override
 	public <T extends Entity> void registerWithRenderer(String name, Class<T> c, Item i, int id) {
-		RenderingRegistry.registerEntityRenderingHandler(c,
-				new ThrowableDefaultRenderFactory<T>(i));
+		RenderingRegistry.registerEntityRenderingHandler(
+				c,
+				new ThrowableDefaultRenderFactory<T>(i)
+		);
 	}
 
 	@Override
 	public <T extends Entity> void registerWithRenderer(String name, Class<T> c,
 			ResourceLocation texture, int id) {
-		RenderingRegistry.registerEntityRenderingHandler(c,
-				new ThrowableAdvancedRenderFactory<T>(texture));
+		RenderingRegistry.registerEntityRenderingHandler(
+				c,
+				new ThrowableAdvancedRenderFactory<T>(texture)
+		);
 	}
 
 	@Override
 	public void registerEntityRenderingHandlers() {
 		RenderingRegistry.registerEntityRenderingHandler(EntityFlare.class, RenderFlare::new);
 	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void addRenderLayer() {
+		final Map<String, RenderPlayer> skinMap = Minecraft.getMinecraft().getRenderManager().getSkinMap();
+		RenderPlayer render;
+		for (final Entry<String, RenderPlayer> map : skinMap.entrySet()) {
+			if (map.getKey().contentEquals("slim")) {
+				render = map.getValue();
+				render.addLayer(new BountfulRenderLayer(true, render));
+			} else {
+				render = map.getValue();
+				render.addLayer(new BountfulRenderLayer(false, render));
+			}
+		}
+	}
+
 }

--- a/src/main/java/cursedflames/bountifulbaubles/proxy/ISideProxy.java
+++ b/src/main/java/cursedflames/bountifulbaubles/proxy/ISideProxy.java
@@ -45,4 +45,8 @@ public interface ISideProxy {
 
 	public default void registerEntityRenderingHandlers() {
 	}
+
+	public default void addRenderLayer() {
+	}
+
 }


### PR DESCRIPTION
By Request of shivaxi.
The Baubles Render layer kind of sucks, and is very limiting, created a custom render layer to allow access to the RenderPlayer, which allows access to the player model and model rotations, and fixes rendering issues with Mo'Bends.
The "getTabIconItem" to "createIcon", and "getUnlocalizedName" to "getTranslationKey", "setUnlocalizedName" to "setTranslationKey" can be ignored, that's just the updated mapping names, and are not required changes, that was my personal preference.